### PR TITLE
:bug: Fix ruleset not found.

### DIFF
--- a/cmd/rules.go
+++ b/cmd/rules.go
@@ -127,12 +127,7 @@ func (r *Rules) addRules(ruleset *api.RuleSet) (err error) {
 		if fileRef == nil {
 			continue
 		}
-		name := strings.Join(
-			[]string{
-				strconv.Itoa(int(ruleset.ID)),
-				fileRef.Name},
-			"-")
-		path := path.Join(ruleDir, name)
+		path := path.Join(ruleDir, fileRef.Name)
 		addon.Activity("[FILE] Get rule: %s", path)
 		err = addon.File.Get(ruleset.File.ID, path)
 		if err != nil {


### PR DESCRIPTION
The RuleSet Rules files are written into a newly created directory, dedicated named using the RuleSet.ID.  Adding the prefix in an effort to avoid name collisions isn't needed and cause a problem with specially named files like `ruleset.yaml`.
As a result, the analyzer ignores the ruleset (and all of its rules) because it cannot find the `ruleset.yaml'.

This results in no issues created.