### PR TITLE
:sparkles: Improved analyzer errors reporting.

### DIFF
--- a/cmd/analyzer.go
+++ b/cmd/analyzer.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"errors"
 	"github.com/konveyor/tackle2-addon-analyzer/builder"
 	"github.com/konveyor/tackle2-addon/command"
 	"path"
@@ -26,12 +25,6 @@ func (r *Analyzer) Run() (b *builder.Issues, err error) {
 	}
 	b = &builder.Issues{Path: output}
 	err = cmd.Run()
-	if err != nil {
-		if errors.Is(err, &RuleError{}) {
-			err.(*RuleError).Report()
-		}
-		return
-	}
 	return
 }
 

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"errors"
 	"github.com/gin-gonic/gin/binding"
 	"github.com/konveyor/tackle2-addon/ssh"
 	hub "github.com/konveyor/tackle2-hub/addon"
@@ -117,6 +118,11 @@ func main() {
 		if err == nil {
 			addon.Activity("Analysis reported. duration: %s", time.Since(mark))
 		} else {
+			ruleErr := &RuleError{}
+			if errors.As(err, &ruleErr) {
+				ruleErr.Report()
+				err = nil
+			}
 			return
 		}
 		//

--- a/cmd/rules.go
+++ b/cmd/rules.go
@@ -76,11 +76,16 @@ func (r *Rules) addFiles() (err error) {
 }
 
 //
-// addRuleSets adds rulesets.
+// addRuleSets adds rulesets and their dependencies.
 func (r *Rules) addRuleSets() (err error) {
+	history := make(map[uint]byte)
 	var add func(refs []api.Ref, dep bool)
 	add = func(refs []api.Ref, dep bool) {
 		for _, ref := range refs {
+			if _, found := history[ref.ID]; found {
+				continue
+			}
+			history[ref.ID] = 0
 			var ruleset *api.RuleSet
 			ruleset, err = addon.RuleSet.Get(ref.ID)
 			if err != nil {

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/gin-gonic/gin v1.9.0
 	github.com/konveyor/analyzer-lsp v0.0.0-20230712145100-60dc2048444c
 	github.com/konveyor/tackle2-addon v0.1.2-0.20230510185644-c600b133619a
-	github.com/konveyor/tackle2-hub v0.2.2-0.20230714131734-a063703e75ce
+	github.com/konveyor/tackle2-hub v0.2.2-0.20230716141827-62f426b6d1a6
 	github.com/onsi/gomega v1.27.6
 	go.lsp.dev/uri v0.3.0
 	gopkg.in/yaml.v3 v3.0.1

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/gin-gonic/gin v1.9.0
 	github.com/konveyor/analyzer-lsp v0.0.0-20230712145100-60dc2048444c
 	github.com/konveyor/tackle2-addon v0.1.2-0.20230510185644-c600b133619a
-	github.com/konveyor/tackle2-hub v0.2.1-0.20230703140704-8e7520555b96
+	github.com/konveyor/tackle2-hub v0.2.2-0.20230714131734-a063703e75ce
 	github.com/onsi/gomega v1.27.6
 	go.lsp.dev/uri v0.3.0
 	gopkg.in/yaml.v3 v3.0.1

--- a/go.sum
+++ b/go.sum
@@ -147,8 +147,8 @@ github.com/konveyor/analyzer-lsp v0.0.0-20230712145100-60dc2048444c h1:DbOZO3cNm
 github.com/konveyor/analyzer-lsp v0.0.0-20230712145100-60dc2048444c/go.mod h1:+k6UreVv8ztI29/RyQN8/71AAmB0aWwQoWwZd3yR8sc=
 github.com/konveyor/tackle2-addon v0.1.2-0.20230510185644-c600b133619a h1:ujBSPC+MzWyF5GRALc7KXd96wJZEuN/ao1meUfvBT2M=
 github.com/konveyor/tackle2-addon v0.1.2-0.20230510185644-c600b133619a/go.mod h1:2poGMxU2vxmz7+FppLvSliMrk0mAtbDHp+LeZ/p2/Q8=
-github.com/konveyor/tackle2-hub v0.2.2-0.20230714131734-a063703e75ce h1:VgRZ4Lwf790DpPtsOsNJyowUSoKL7gB4fFlq+3frEmw=
-github.com/konveyor/tackle2-hub v0.2.2-0.20230714131734-a063703e75ce/go.mod h1:UR7IJ1Qa9RgcdsO81yLWjTB6h7Qz1Y2bypu6YU2LFg8=
+github.com/konveyor/tackle2-hub v0.2.2-0.20230716141827-62f426b6d1a6 h1:A4vgEkHF1jJnTpL2uU8sDPJ+iQQAYl16QXgSILx3gTQ=
+github.com/konveyor/tackle2-hub v0.2.2-0.20230716141827-62f426b6d1a6/go.mod h1:UR7IJ1Qa9RgcdsO81yLWjTB6h7Qz1Y2bypu6YU2LFg8=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
 github.com/kr/pretty v0.2.0/go.mod h1:ipq/a2n7PKx3OHsz4KJII5eveXtPO4qwEXGdVfWzfnI=
 github.com/kr/pretty v0.2.1/go.mod h1:ipq/a2n7PKx3OHsz4KJII5eveXtPO4qwEXGdVfWzfnI=

--- a/go.sum
+++ b/go.sum
@@ -147,8 +147,8 @@ github.com/konveyor/analyzer-lsp v0.0.0-20230712145100-60dc2048444c h1:DbOZO3cNm
 github.com/konveyor/analyzer-lsp v0.0.0-20230712145100-60dc2048444c/go.mod h1:+k6UreVv8ztI29/RyQN8/71AAmB0aWwQoWwZd3yR8sc=
 github.com/konveyor/tackle2-addon v0.1.2-0.20230510185644-c600b133619a h1:ujBSPC+MzWyF5GRALc7KXd96wJZEuN/ao1meUfvBT2M=
 github.com/konveyor/tackle2-addon v0.1.2-0.20230510185644-c600b133619a/go.mod h1:2poGMxU2vxmz7+FppLvSliMrk0mAtbDHp+LeZ/p2/Q8=
-github.com/konveyor/tackle2-hub v0.2.1-0.20230703140704-8e7520555b96 h1:ad9WGM95eq1xcLdxQzVv3Kk71s5322iXv3Cj7vJffD8=
-github.com/konveyor/tackle2-hub v0.2.1-0.20230703140704-8e7520555b96/go.mod h1:UR7IJ1Qa9RgcdsO81yLWjTB6h7Qz1Y2bypu6YU2LFg8=
+github.com/konveyor/tackle2-hub v0.2.2-0.20230714131734-a063703e75ce h1:VgRZ4Lwf790DpPtsOsNJyowUSoKL7gB4fFlq+3frEmw=
+github.com/konveyor/tackle2-hub v0.2.2-0.20230714131734-a063703e75ce/go.mod h1:UR7IJ1Qa9RgcdsO81yLWjTB6h7Qz1Y2bypu6YU2LFg8=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
 github.com/kr/pretty v0.2.0/go.mod h1:ipq/a2n7PKx3OHsz4KJII5eveXtPO4qwEXGdVfWzfnI=
 github.com/kr/pretty v0.2.1/go.mod h1:ipq/a2n7PKx3OHsz4KJII5eveXtPO4qwEXGdVfWzfnI=


### PR DESCRIPTION
Appends analyzer reported errors to the TaskReport.Errors.
Prevent downloading duplicate rulesets.
closes: #26 