### PR TITLE
:bug: Fixes YAML encoding/decoding issue for codeSnip.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,13 +1,12 @@
-GOBIN ?= ${GOPATH}/bin
-IMG   ?= quay.io/konveyor/tackle2-addon-analyzer:latest
+GOBIN    ?= ${GOPATH}/bin
+IMG      ?= quay.io/konveyor/tackle2-addon-analyzer:latest
+CMD      ?= bin/addon
+AddonDir ?= /tmp/addon
 
-all: cmd
-
-fmt:
+${CMD}:
 	go fmt ./...
-
-vet:
 	go vet ./...
+	go build -ldflags="-w -s" -o $@ github.com/konveyor/tackle2-addon-analyzer/cmd
 
 image-docker:
 	docker build -t ${IMG} .
@@ -15,5 +14,16 @@ image-docker:
 image-podman:
 	podman build -t ${IMG} .
 
-cmd: fmt vet
-	go build -ldflags="-w -s" -o bin/addon github.com/konveyor/tackle2-addon-analyzer/cmd
+run: ${CMD}
+	mkdir -p ${AddonDir}
+	$(eval cmd := $(abspath ${CMD}))
+	cd ${AddonDir};${cmd}
+
+fmt:
+	go fmt ./...
+
+vet:
+	go vet ./...
+
+clean:
+	rm -f ${CMD}

--- a/builder/deps.go
+++ b/builder/deps.go
@@ -3,7 +3,7 @@ package builder
 import (
 	output "github.com/konveyor/analyzer-lsp/output/v1/konveyor"
 	"github.com/konveyor/tackle2-hub/api"
-	"gopkg.in/yaml.v3"
+	"gopkg.in/yaml.v2"
 	"io"
 	"os"
 )

--- a/builder/issue.go
+++ b/builder/issue.go
@@ -6,7 +6,7 @@ import (
 	hub "github.com/konveyor/tackle2-hub/addon"
 	"github.com/konveyor/tackle2-hub/api"
 	"go.lsp.dev/uri"
-	"gopkg.in/yaml.v3"
+	"gopkg.in/yaml.v2"
 	"io"
 	"os"
 )

--- a/cmd/settings.go
+++ b/cmd/settings.go
@@ -3,7 +3,7 @@ package main
 import (
 	"bufio"
 	"github.com/konveyor/analyzer-lsp/provider"
-	"gopkg.in/yaml.v3"
+	"gopkg.in/yaml.v2"
 	"io"
 	"os"
 	"path"

--- a/go.mod
+++ b/go.mod
@@ -6,10 +6,10 @@ require (
 	github.com/gin-gonic/gin v1.9.0
 	github.com/konveyor/analyzer-lsp v0.0.0-20230712145100-60dc2048444c
 	github.com/konveyor/tackle2-addon v0.1.2-0.20230510185644-c600b133619a
-	github.com/konveyor/tackle2-hub v0.2.2-0.20230716141827-62f426b6d1a6
+	github.com/konveyor/tackle2-hub v0.2.2-0.20230717165033-e6abb80e8aee
 	github.com/onsi/gomega v1.27.6
 	go.lsp.dev/uri v0.3.0
-	gopkg.in/yaml.v3 v3.0.1
+	gopkg.in/yaml.v2 v2.4.0
 )
 
 require (
@@ -94,7 +94,7 @@ require (
 	google.golang.org/grpc v1.54.0 // indirect
 	google.golang.org/protobuf v1.30.0 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
-	gopkg.in/yaml.v2 v2.4.0 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
 	gorm.io/datatypes v1.2.0 // indirect
 	gorm.io/driver/mysql v1.4.7 // indirect
 	gorm.io/gorm v1.25.2-0.20230530020048-26663ab9bf55 // indirect

--- a/go.sum
+++ b/go.sum
@@ -147,8 +147,8 @@ github.com/konveyor/analyzer-lsp v0.0.0-20230712145100-60dc2048444c h1:DbOZO3cNm
 github.com/konveyor/analyzer-lsp v0.0.0-20230712145100-60dc2048444c/go.mod h1:+k6UreVv8ztI29/RyQN8/71AAmB0aWwQoWwZd3yR8sc=
 github.com/konveyor/tackle2-addon v0.1.2-0.20230510185644-c600b133619a h1:ujBSPC+MzWyF5GRALc7KXd96wJZEuN/ao1meUfvBT2M=
 github.com/konveyor/tackle2-addon v0.1.2-0.20230510185644-c600b133619a/go.mod h1:2poGMxU2vxmz7+FppLvSliMrk0mAtbDHp+LeZ/p2/Q8=
-github.com/konveyor/tackle2-hub v0.2.2-0.20230716141827-62f426b6d1a6 h1:A4vgEkHF1jJnTpL2uU8sDPJ+iQQAYl16QXgSILx3gTQ=
-github.com/konveyor/tackle2-hub v0.2.2-0.20230716141827-62f426b6d1a6/go.mod h1:UR7IJ1Qa9RgcdsO81yLWjTB6h7Qz1Y2bypu6YU2LFg8=
+github.com/konveyor/tackle2-hub v0.2.2-0.20230717165033-e6abb80e8aee h1:nyC+LxMlZVznC0YsjJAczkX3Ke287QLgWiXUyzi5z5U=
+github.com/konveyor/tackle2-hub v0.2.2-0.20230717165033-e6abb80e8aee/go.mod h1:WVwCkC7YtGwT9gH5hWUmxxZKvCq8lqIxMHo2i6LEGzA=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
 github.com/kr/pretty v0.2.0/go.mod h1:ipq/a2n7PKx3OHsz4KJII5eveXtPO4qwEXGdVfWzfnI=
 github.com/kr/pretty v0.2.1/go.mod h1:ipq/a2n7PKx3OHsz4KJII5eveXtPO4qwEXGdVfWzfnI=

--- a/hack/README.md
+++ b/hack/README.md
@@ -1,0 +1,35 @@
+Running the addon locally is relatively straight forward:
+
+Set environment variables:
+- The `HUB_BASE_URL` must be set when not running the hub locally.
+- The `TASK` **must** be set.
+- The `TOKEN` must be set when auth is enabled in the hub.
+
+The addon runs analyzer (CLI) commands:
+- /usr/bin/konveyor-analyzer
+- /usr/bin/konveyor-analyzer-dep
+
+These commands have dependencies that can be complicated to install and
+most developers won't want to install them in their development environment.
+The recommended method is to run the commands in docker using the _quay.io/konveyor/analyzer-lsp_
+image. A wrapper for these commands is provided in `hack/` which can be linked into `/usr/bin`.
+
+The `reset` script should be invoked before each run:
+- (re)creates /tmp/addon.
+- copies settings.json to /tmp/addon/opt.
+
+Example:
+```
+sudo ln -s hack/konveyor-analyzer /usr/bin
+sudo ln -s hack/konveyor-analyzer-dep /usr/bin
+```
+
+Example: with Hub running in minikube.
+```
+$ minikube ip
+192.168.49.2
+$ export HUB_BASE_URL=http://192.168.49.2/hub
+$ export TASK=1
+$ reset
+$ make run
+```

--- a/hack/konveyor-analyzer
+++ b/hack/konveyor-analyzer
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+
+image=${IMAGE-quay.io/konveyor/analyzer-lsp}
+
+if [ -z "${image}" ]
+then
+  exit
+fi
+
+addon=/tmp/addon
+
+params=()
+for p in "$@"
+do
+  params+=("$p")
+done
+
+docker run \
+  -v ${addon}:${addon} \
+  ${image} \
+  "${params[@]}"
+

--- a/hack/konveyor-analyzer-dep
+++ b/hack/konveyor-analyzer-dep
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+
+image=${IMAGE-quay.io/konveyor/analyzer-lsp}
+
+if [ -z "${image}" ]
+then
+  exit
+fi
+
+addon=/tmp/addon
+
+params=()
+for p in "$@"
+do
+  params+=("$p")
+done
+docker run \
+  -v ${addon}:${addon} \
+  --entrypoint /usr/bin/konveyor-analyzer-dep \
+  ${image} \
+  "${params[@]}"
+

--- a/hack/reset
+++ b/hack/reset
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+addon=/tmp/addon
+opt=${addon}/opt
+
+rm -rf ${addon}
+mkdir -p ${opt}
+cp $(dirname $0)/../settings.json ${opt}
+


### PR DESCRIPTION
fixes: #24 

Adds (2) shell scripts to run the analyzer in docker.  Handy when running the addon locally.