### PR TITLE
:sparkles: Run windup-shim.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,5 @@
+FROM quay.io/konveyor/windup-shim:latest as shim
+
 FROM registry.access.redhat.com/ubi9/go-toolset:latest as addon
 ENV GOPATH=$APP_ROOT
 COPY --chown=1001:0 . .
@@ -18,6 +20,7 @@ RUN microdnf -y install \
 ENV HOME=/addon ADDON=/addon
 WORKDIR /addon
 ARG GOPATH=/opt/app-root
+COPY --from=shim /usr/bin/windup-shim /usr/bin
 COPY --from=addon $GOPATH/src/settings.json $ADDON/opt/settings.json
 COPY --from=addon $GOPATH/src/bin/addon /usr/bin
 ENTRYPOINT ["/usr/bin/addon"]

--- a/cmd/rules.go
+++ b/cmd/rules.go
@@ -5,6 +5,7 @@ import (
 	"github.com/konveyor/tackle2-addon/repository"
 	"github.com/konveyor/tackle2-hub/api"
 	"github.com/konveyor/tackle2-hub/nas"
+	"os"
 	"path"
 	"strconv"
 	"strings"
@@ -36,6 +37,10 @@ func (r *Rules) Build() (err error) {
 		return
 	}
 	err = r.addRuleSets()
+	if err != nil {
+		return
+	}
+	err = r.convert()
 	if err != nil {
 		return
 	}
@@ -223,6 +228,28 @@ func (r *Rules) addSelector(options *command.Options) (err error) {
 	selector := ruleSelector.String()
 	if selector != "" {
 		options.Add("--label-selector", selector)
+	}
+	return
+}
+
+//
+// convert windup rules.
+func (r *Rules) convert() (err error) {
+	output := path.Join(RuleDir, "converted")
+	cmd := command.Command{Path: "/usr/bin/windup-shim"}
+	cmd.Options.Add("convert")
+	cmd.Options.Add("--outputdir", output)
+	cmd.Options.Add(RuleDir)
+	err = cmd.Run()
+	if err != nil {
+		return
+	}
+	converted, err := os.ReadDir(output)
+	if err != nil {
+		return
+	}
+	if len(converted) > 0 {
+		r.rules = append(r.rules, output)
 	}
 	return
 }

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/gin-gonic/gin v1.9.0
 	github.com/konveyor/analyzer-lsp v0.0.0-20230712145100-60dc2048444c
 	github.com/konveyor/tackle2-addon v0.1.2-0.20230510185644-c600b133619a
-	github.com/konveyor/tackle2-hub v0.2.2-0.20230717165033-e6abb80e8aee
+	github.com/konveyor/tackle2-hub v0.2.2-0.20230719161216-735ce250924b
 	github.com/onsi/gomega v1.27.6
 	go.lsp.dev/uri v0.3.0
 	gopkg.in/yaml.v2 v2.4.0

--- a/go.sum
+++ b/go.sum
@@ -147,8 +147,8 @@ github.com/konveyor/analyzer-lsp v0.0.0-20230712145100-60dc2048444c h1:DbOZO3cNm
 github.com/konveyor/analyzer-lsp v0.0.0-20230712145100-60dc2048444c/go.mod h1:+k6UreVv8ztI29/RyQN8/71AAmB0aWwQoWwZd3yR8sc=
 github.com/konveyor/tackle2-addon v0.1.2-0.20230510185644-c600b133619a h1:ujBSPC+MzWyF5GRALc7KXd96wJZEuN/ao1meUfvBT2M=
 github.com/konveyor/tackle2-addon v0.1.2-0.20230510185644-c600b133619a/go.mod h1:2poGMxU2vxmz7+FppLvSliMrk0mAtbDHp+LeZ/p2/Q8=
-github.com/konveyor/tackle2-hub v0.2.2-0.20230717165033-e6abb80e8aee h1:nyC+LxMlZVznC0YsjJAczkX3Ke287QLgWiXUyzi5z5U=
-github.com/konveyor/tackle2-hub v0.2.2-0.20230717165033-e6abb80e8aee/go.mod h1:WVwCkC7YtGwT9gH5hWUmxxZKvCq8lqIxMHo2i6LEGzA=
+github.com/konveyor/tackle2-hub v0.2.2-0.20230719161216-735ce250924b h1:E6PNOg7Hys+wKNmMrynOo5SXRpPx3AyG0BqN3LxwFs0=
+github.com/konveyor/tackle2-hub v0.2.2-0.20230719161216-735ce250924b/go.mod h1:WVwCkC7YtGwT9gH5hWUmxxZKvCq8lqIxMHo2i6LEGzA=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
 github.com/kr/pretty v0.2.0/go.mod h1:ipq/a2n7PKx3OHsz4KJII5eveXtPO4qwEXGdVfWzfnI=
 github.com/kr/pretty v0.2.1/go.mod h1:ipq/a2n7PKx3OHsz4KJII5eveXtPO4qwEXGdVfWzfnI=

--- a/hack/README.md
+++ b/hack/README.md
@@ -20,8 +20,9 @@ The `reset` script should be invoked before each run:
 
 Example:
 ```
-sudo ln -s hack/konveyor-analyzer /usr/bin
-sudo ln -s hack/konveyor-analyzer-dep /usr/bin
+sudo ln -s $(pwd)/hack/windup-shim /usr/bin
+sudo ln -s $(pwd)/hack/konveyor-analyzer /usr/bin
+sudo ln -s $(pwd)/hack/konveyor-analyzer-dep /usr/bin
 ```
 
 Example: with Hub running in minikube.

--- a/hack/windup-shim
+++ b/hack/windup-shim
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+
+image=${IMAGE-quay.io/konveyor/windup-shim}
+
+if [ -z "${image}" ]
+then
+  exit
+fi
+
+addon=/tmp/addon
+
+params=()
+for p in "$@"
+do
+  params+=("$p")
+done
+
+docker run \
+  -v ${addon}:${addon} \
+  ${image} \
+  "${params[@]}"
+

--- a/settings.json
+++ b/settings.json
@@ -2,28 +2,32 @@
     {
         "name": "go",
         "binaryPath": "/usr/bin/golang-external-provider",
-        "initConfig": [{
-            "lspServerPath": "/root/go/bin/gopls",
-            "analysisMode": "full"
-        }]
+        "initConfig": [
+            {
+               "analysisMode": "full",
+                "providerSpecificConfig": {
+                    "lspServerPath": "/root/go/bin/gopls"
+                }
+            }
+        ]
     },
     {
         "name": "java",
         "binaryPath": "/jdtls/bin/jdtls",
         "initConfig": [
             {
-                "lspServerPath": "/jdtls/bin/jdtls",
+                "analysisMode": "source-only",
                 "providerSpecificConfig": {
-                    "bundles": "/jdtls/java-analyzer-bundle/java-analyzer-bundle.core/target/java-analyzer-bundle.core-1.0.0-SNAPSHOT.jar"
-                },
-                "analysisMode": "source-only"
-            },
+                    "bundles": "/jdtls/java-analyzer-bundle/java-analyzer-bundle.core/target/java-analyzer-bundle.core-1.0.0-SNAPSHOT.jar",
+                    "lspServerPath": "/jdtls/bin/jdtls"
+                }
+            }
         ]
     },
     {
         "name": "builtin",
         "initConfig": [
-            {},
+            {}
         ]
     }
 ]


### PR DESCRIPTION
Run windup-shim on rules/ which converts windup rules which are written into rules/converted.

Also:
- latest hub binding.
- latest analyzer-lsp image.  Minor change for campat with provider settings API.


closes: #8 