### PR TITLE
:sparkles: propagate proxy settings.

### DIFF
--- a/cmd/analyzer.go
+++ b/cmd/analyzer.go
@@ -58,6 +58,10 @@ func (r *Analyzer) options(output string) (options command.Options, err error) {
 	if err != nil {
 		return
 	}
+	err = settings.ProxySettings()
+	if err != nil {
+		return
+	}
 	err = settings.Write()
 	if err != nil {
 		return

--- a/cmd/settings.go
+++ b/cmd/settings.go
@@ -159,7 +159,7 @@ func (r *Settings) getProxy(kind string) (url string, excluded []string, err err
 	if p.Port > 0 {
 		host += ":" + strconv.Itoa(p.Port)
 	}
-	url = "http://" + host
+	url = kind + "://" + host
 	return
 }
 

--- a/cmd/settings.go
+++ b/cmd/settings.go
@@ -138,7 +138,6 @@ func (r *Settings) getProxy(kind string) (url string, excluded []string, err err
 	if p.Host == "" {
 		return
 	}
-	excluded = p.Excluded
 	if p.Identity != nil {
 		id, err = addon.Identity.Get(p.Identity.ID)
 		if err == nil {
@@ -156,6 +155,7 @@ func (r *Settings) getProxy(kind string) (url string, excluded []string, err err
 		host += ":" + strconv.Itoa(p.Port)
 	}
 	url = "http://" + host
+	excluded = p.Excluded
 	return
 }
 

--- a/cmd/settings.go
+++ b/cmd/settings.go
@@ -134,7 +134,7 @@ func (r *Settings) getProxy(kind string) (url string, excluded []string, err err
 	var user, password string
 	p, err = addon.Proxy.Find(kind)
 	if err != nil {
-		if errors.Is(err, &hub.Conflict{}) {
+		if errors.Is(err, &hub.NotFound{}) {
 			err = nil
 			return
 		}

--- a/cmd/settings.go
+++ b/cmd/settings.go
@@ -138,16 +138,15 @@ func (r *Settings) getProxy(kind string) (url string, excluded []string, err err
 	if p.Host == "" {
 		return
 	}
+	excluded = p.Excluded
 	if p.Identity != nil {
 		id, err = addon.Identity.Get(p.Identity.ID)
-		if err != nil {
+		if err == nil {
+			user = id.User
+			password = id.Password
+		} else {
 			return
 		}
-		user = id.User
-		password = id.Password
-		excluded = append(
-			excluded,
-			p.Excluded...)
 	}
 	host := p.Host
 	if user != "" && password != "" {

--- a/cmd/settings.go
+++ b/cmd/settings.go
@@ -93,13 +93,17 @@ func (r *Settings) ProxySettings() (err error) {
 	var excluded, noproxy []string
 	http, excluded, err = r.getProxy("http")
 	if err == nil {
-		noproxy = append(noproxy, excluded...)
+		noproxy = append(
+			noproxy,
+			excluded...)
 	} else {
 		return
 	}
 	https, excluded, err = r.getProxy("https")
 	if err == nil {
-		noproxy = append(noproxy, excluded...)
+		noproxy = append(
+			noproxy,
+			excluded...)
 	} else {
 		return
 	}

--- a/cmd/settings.go
+++ b/cmd/settings.go
@@ -148,6 +148,7 @@ func (r *Settings) getProxy(kind string) (url string, excluded []string, err err
 		}
 	}
 	host := p.Host
+	excluded = p.Excluded
 	if user != "" && password != "" {
 		host = user + ":" + password + "@" + host
 	}
@@ -155,7 +156,6 @@ func (r *Settings) getProxy(kind string) (url string, excluded []string, err err
 		host += ":" + strconv.Itoa(p.Port)
 	}
 	url = "http://" + host
-	excluded = p.Excluded
 	return
 }
 


### PR DESCRIPTION
Set provider proxy settings.

Note: both http and https proxies are seeded.  They are only used when `host` is populated.

closes #21 