### PR TITLE
:ghost: using non-absolute paths to commands.

### DIFF
--- a/cmd/analyzer.go
+++ b/cmd/analyzer.go
@@ -18,7 +18,7 @@ type Analyzer struct {
 // Run analyzer.
 func (r *Analyzer) Run() (b *builder.Issues, err error) {
 	output := path.Join(Dir, "report.yaml")
-	cmd := command.Command{Path: "/usr/bin/konveyor-analyzer"}
+	cmd := command.Command{Path: "konveyor-analyzer"}
 	cmd.Options, err = r.options(output)
 	if err != nil {
 		return
@@ -80,7 +80,7 @@ type DepAnalyzer struct {
 // Run analyzer.
 func (r *DepAnalyzer) Run() (b *builder.Deps, err error) {
 	output := path.Join(Dir, "deps.yaml")
-	cmd := command.Command{Path: "/usr/bin/konveyor-analyzer-dep"}
+	cmd := command.Command{Path: "konveyor-analyzer-dep"}
 	cmd.Options, err = r.options(output)
 	if err != nil {
 		return

--- a/cmd/rules.go
+++ b/cmd/rules.go
@@ -236,7 +236,7 @@ func (r *Rules) addSelector(options *command.Options) (err error) {
 // convert windup rules.
 func (r *Rules) convert() (err error) {
 	output := path.Join(RuleDir, "converted")
-	cmd := command.Command{Path: "/usr/bin/windup-shim"}
+	cmd := command.Command{Path: "windup-shim"}
 	cmd.Options.Add("convert")
 	cmd.Options.Add("--outputdir", output)
 	cmd.Options.Add(RuleDir)


### PR DESCRIPTION
Find konveyor commands in the _usual_ locations for each OS.  This better supports running the addon locally.
Mainly because MacOS [IPS](https://en.wikipedia.org/wiki/System_Integrity_Protection) won't let developers install into /usr/bin.