### PR TITLE
:ghost: get/pass maven settings for all source modes.

### DIFF
--- a/cmd/analyzer.go
+++ b/cmd/analyzer.go
@@ -46,7 +46,7 @@ func (r *Analyzer) options(output string) (options command.Options, err error) {
 	if err != nil {
 		return
 	}
-	err = r.Mode.AddOptions(options, settings)
+	err = r.Mode.AddOptions(&options, settings)
 	if err != nil {
 		return
 	}
@@ -107,7 +107,7 @@ func (r *DepAnalyzer) options(output string) (options command.Options, err error
 		"--output-file",
 		output,
 	}
-	err = r.Mode.AddOptions(options, settings)
+	err = r.Mode.AddDepOptions(&options, settings)
 	if err != nil {
 		return
 	}

--- a/cmd/analyzer.go
+++ b/cmd/analyzer.go
@@ -46,7 +46,7 @@ func (r *Analyzer) options(output string) (options command.Options, err error) {
 	if err != nil {
 		return
 	}
-	err = r.Mode.AddOptions(settings)
+	err = r.Mode.AddOptions(options, settings)
 	if err != nil {
 		return
 	}
@@ -107,7 +107,7 @@ func (r *DepAnalyzer) options(output string) (options command.Options, err error
 		"--output-file",
 		output,
 	}
-	err = r.Mode.AddOptions(settings)
+	err = r.Mode.AddOptions(options, settings)
 	if err != nil {
 		return
 	}

--- a/cmd/mode.go
+++ b/cmd/mode.go
@@ -15,10 +15,11 @@ import (
 //
 // Mode settings.
 type Mode struct {
-	Binary     bool   `json:"binary"`
-	Artifact   string `json:"artifact"`
-	WithDeps   bool   `json:"withDeps"`
-	Repository repository.SCM
+	Binary        bool   `json:"binary"`
+	Artifact      string `json:"artifact"`
+	WithDeps      bool   `json:"withDeps"`
+	WithKnownLibs bool   `json:"withKnownLibs"`
+	Repository    repository.SCM
 	//
 	path struct {
 		appDir string
@@ -56,7 +57,7 @@ func (r *Mode) Build(application *api.Application) (err error) {
 
 //
 // AddOptions adds analyzer options.
-func (r *Mode) AddOptions(options command.Options, settings *Settings) (err error) {
+func (r *Mode) AddOptions(options *command.Options, settings *Settings) (err error) {
 	if r.WithDeps {
 		settings.MavenSettings(r.path.maven.settings)
 		settings.Mode(provider.FullAnalysisMode)
@@ -68,6 +69,18 @@ func (r *Mode) AddOptions(options command.Options, settings *Settings) (err erro
 		settings.Location(r.path.binary)
 	} else {
 		settings.Location(r.path.appDir)
+	}
+	return
+}
+
+//
+// AddDepOptions adds analyzer-dep options.
+func (r *Mode) AddDepOptions(options *command.Options, settings *Settings) (err error) {
+	settings.Location(r.path.appDir)
+	if !r.WithKnownLibs {
+		options.Add(
+			"--dep-label-selector",
+			"!konveyor.io/dep-source=open-source")
 	}
 	return
 }

--- a/cmd/mode.go
+++ b/cmd/mode.go
@@ -3,6 +3,7 @@ package main
 import (
 	"errors"
 	"github.com/konveyor/analyzer-lsp/provider"
+	"github.com/konveyor/tackle2-addon/command"
 	"github.com/konveyor/tackle2-addon/repository"
 	"github.com/konveyor/tackle2-hub/api"
 	"github.com/konveyor/tackle2-hub/nas"
@@ -55,12 +56,13 @@ func (r *Mode) Build(application *api.Application) (err error) {
 
 //
 // AddOptions adds analyzer options.
-func (r *Mode) AddOptions(settings *Settings) (err error) {
+func (r *Mode) AddOptions(options command.Options, settings *Settings) (err error) {
 	if r.WithDeps {
 		settings.MavenSettings(r.path.maven.settings)
 		settings.Mode(provider.FullAnalysisMode)
 	} else {
 		settings.Mode(provider.SourceOnlyAnalysisMode)
+		options.Add("--no-dependency-rules")
 	}
 	if r.Binary {
 		settings.Location(r.path.binary)


### PR DESCRIPTION
Pass `--no-dependency-rules` to the analyzer for source (only) mode.

Added Mode.WithKnownLibs (bool). 
When FALSE (default), pass `--dep-label-selector !konveyor.io/dep-source=open-source` to the analyzer-dep.