### PR TITLE
:bug: : Handle incident URI with custom schemes.

### DIFF
--- a/builder/issue.go
+++ b/builder/issue.go
@@ -8,6 +8,7 @@ import (
 	"go.lsp.dev/uri"
 	"gopkg.in/yaml.v2"
 	"io"
+	"net/url"
 	"os"
 )
 
@@ -119,11 +120,13 @@ func (b *Issues) read() (input []output.RuleSet, err error) {
 
 //
 // uniStr (safely) returns URI filename.
-func (b *Issues) uriStr(in uri.URI) string {
-	defer func() {
-		recover()
-	}()
-	return in.Filename()
+func (b *Issues) uriStr(in uri.URI) (s string) {
+	s = string(in)
+	u, err := url.Parse(s)
+	if err == nil {
+		s = u.Path
+	}
+	return
 }
 
 //


### PR DESCRIPTION
Fixes blank Incident.File.
The analyzer creates URIs with custom schemes which is not compatible with the Go [uri](https://pkg.go.dev/go.lsp.dev/uri) package which only supports (file,http,https).  Using the [url](https://pkg.go.dev/net/url) package to parse instead is safe because the `uri` package uses the `url` internally anyway.  Fall back on _raw_ URI string on parsing error.
