### PR TITLE
:bug: --dep-label-selector passed to analyzer.

### DIFF
--- a/cmd/mode.go
+++ b/cmd/mode.go
@@ -65,6 +65,11 @@ func (r *Mode) AddOptions(options *command.Options, settings *Settings) (err err
 		settings.Mode(provider.SourceOnlyAnalysisMode)
 		options.Add("--no-dependency-rules")
 	}
+	if !r.WithKnownLibs {
+		options.Add(
+			"--dep-label-selector",
+			"!konveyor.io/dep-source=open-source")
+	}
 	if r.Binary {
 		settings.Location(r.path.binary)
 	} else {
@@ -77,11 +82,6 @@ func (r *Mode) AddOptions(options *command.Options, settings *Settings) (err err
 // AddDepOptions adds analyzer-dep options.
 func (r *Mode) AddDepOptions(options *command.Options, settings *Settings) (err error) {
 	settings.Location(r.path.appDir)
-	if !r.WithKnownLibs {
-		options.Add(
-			"--dep-label-selector",
-			"!konveyor.io/dep-source=open-source")
-	}
 	return
 }
 


### PR DESCRIPTION
https://github.com/konveyor/analyzer-lsp/issues/318#issuecomment-1716318254

When _with-known-libraries_ is not requested:
```
 - '[CMD] Running: /usr/bin/konveyor-analyzer --provider-settings /addon/opt/settings.json --output-file /addon/report.yaml --dep-label-selector !konveyor.io/dep-source=open-source --rules /addon/rules/rulesets/1/rules --rules /addon/rules/rulesets/18/rules --rules /addon/rules/rulesets/22/rules --rules /addon/rules/rulesets/19/rules --rules /addon/rules/converted --label-selector (konveyor.io/target=cloud-readiness||konveyor.io/target=linux)'
 ```