### PR TITLE
:bug: ensure converted directory is created.

### DIFF
--- a/cmd/rules.go
+++ b/cmd/rules.go
@@ -266,6 +266,10 @@ func (r *Rules) addSelector(options *command.Options) (err error) {
 // convert windup rules.
 func (r *Rules) convert() (err error) {
 	output := path.Join(RuleDir, "converted")
+	err = nas.MkDir(output, 0755)
+	if err != nil {
+		return
+	}
 	cmd := command.Command{Path: "/usr/bin/windup-shim"}
 	cmd.Options.Add("convert")
 	cmd.Options.Add("--outputdir", output)


### PR DESCRIPTION
Not sure what changed in the shim (or rulesets) but using :latest, the output directory is only created when rules are converted.  Better practice to not rely on the shim creating it.

Fixes:
```
errors:
    - severity: Error
      description: 'open /addon/rules/converted: no such file or directory'
    - severity: Error
      description: 'Pod failed: Error'
```