### PR TITLE
:bug: Support incident selectors.

### DIFF
--- a/cmd/cmd_test.go
+++ b/cmd/cmd_test.go
@@ -101,3 +101,27 @@ func TestLabelMatch(t *testing.T) {
 	rule = "konveyor.io/target=thing4-"
 	g.Expect(rule.Match(included)).To(gomega.BeTrue())
 }
+
+func TestIncidentSelector(t *testing.T) {
+	g := gomega.NewGomegaWithT(t)
+	// Empty.
+	scope := Scope{}
+	selector := scope.incidentSelector()
+	g.Expect("").To(gomega.Equal(selector))
+	// Included.
+	scope = Scope{}
+	scope.Packages.Included = []string{"a", "b"}
+	selector = scope.incidentSelector()
+	g.Expect("(!package||package=a||package=b)").To(gomega.Equal(selector))
+	// Excluded.
+	scope = Scope{}
+	scope.Packages.Excluded = []string{"C", "D"}
+	selector = scope.incidentSelector()
+	g.Expect("!(package||package=C||package=D)").To(gomega.Equal(selector))
+	// Included and Excluded.
+	scope = Scope{}
+	scope.Packages.Included = []string{"a", "b"}
+	scope.Packages.Excluded = []string{"C", "D"}
+	selector = scope.incidentSelector()
+	g.Expect("(!package||package=a||package=b)&&!(package||package=C||package=D)").To(gomega.Equal(selector))
+}

--- a/cmd/cmd_test.go
+++ b/cmd/cmd_test.go
@@ -123,5 +123,5 @@ func TestIncidentSelector(t *testing.T) {
 	scope.Packages.Included = []string{"a", "b"}
 	scope.Packages.Excluded = []string{"C", "D"}
 	selector = scope.incidentSelector()
-	g.Expect("(!package||package=a||package=b)&&!(package||package=C||package=D)").To(gomega.Equal(selector))
+	g.Expect("(!package||package=a||package=b) && !(package=C||package=D)").To(gomega.Equal(selector))
 }

--- a/cmd/scope.go
+++ b/cmd/scope.go
@@ -48,9 +48,13 @@ func (r *Scope) incidentSelector() (selector string) {
 	}
 	p = predicate(r.Packages.Excluded)
 	if len(p) > 0 {
-		p = "!(package||" + p + ")"
+		if len(predicates) == 0 {
+			p = "!(package||" + p + ")"
+		} else {
+			p = "!(" + p + ")"
+		}
 		predicates = append(predicates, p)
 	}
-	selector = strings.Join(predicates, "&&")
+	selector = strings.Join(predicates, " && ")
 	return
 }

--- a/cmd/scope.go
+++ b/cmd/scope.go
@@ -30,7 +30,7 @@ func (r *Scope) AddOptions(options *command.Options) (err error) {
 
 //
 // incidentSelector returns an incident selector.
-// The `!package` matches incidents without a package variable.
+// The injected `!package` matches incidents without a package variable.
 func (r *Scope) incidentSelector() (selector string) {
 	predicate := func(in []string) (p string) {
 		var refs []string

--- a/cmd/scope.go
+++ b/cmd/scope.go
@@ -23,7 +23,7 @@ func (r *Scope) AddOptions(options *command.Options) (err error) {
 	}
 	selector := r.incidentSelector()
 	if selector != "" {
-		options.Add("--incidentSelector", selector)
+		options.Add("--incident-selector", selector)
 	}
 	return
 }

--- a/cmd/scope.go
+++ b/cmd/scope.go
@@ -30,6 +30,7 @@ func (r *Scope) AddOptions(options *command.Options) (err error) {
 
 //
 // incidentSelector returns an incident selector.
+// The `!package` matches rules without a package specification.
 func (r *Scope) incidentSelector() (selector string) {
 	predicate := func(in []string) (p string) {
 		var refs []string

--- a/cmd/scope.go
+++ b/cmd/scope.go
@@ -1,6 +1,9 @@
 package main
 
-import "github.com/konveyor/tackle2-addon/command"
+import (
+	"github.com/konveyor/tackle2-addon/command"
+	"strings"
+)
 
 // Scope settings.
 type Scope struct {
@@ -18,11 +21,35 @@ func (r *Scope) AddOptions(options *command.Options) (err error) {
 			"--dep-label-selector",
 			"!konveyor.io/dep-source=open-source")
 	}
-	if len(r.Packages.Included) > 0 {
-		options.Add("--packages", r.Packages.Included...)
+	selector := r.incidentSelector()
+	if selector != "" {
+		options.Add("--incidentSelector", selector)
 	}
-	if len(r.Packages.Excluded) > 0 {
-		options.Add("--excludePackages", r.Packages.Excluded...)
+	return
+}
+
+//
+// incidentSelector returns an incident selector.
+func (r *Scope) incidentSelector() (selector string) {
+	predicate := func(in []string) (p string) {
+		var refs []string
+		for _, s := range in {
+			refs = append(refs, "package="+s)
+		}
+		p = strings.Join(refs, "||")
+		return
 	}
+	var predicates []string
+	p := predicate(r.Packages.Included)
+	if len(p) > 0 {
+		p = "(!package||" + p + ")"
+		predicates = append(predicates, p)
+	}
+	p = predicate(r.Packages.Excluded)
+	if len(p) > 0 {
+		p = "!(package||" + p + ")"
+		predicates = append(predicates, p)
+	}
+	selector = strings.Join(predicates, "&&")
 	return
 }

--- a/cmd/scope.go
+++ b/cmd/scope.go
@@ -30,7 +30,7 @@ func (r *Scope) AddOptions(options *command.Options) (err error) {
 
 //
 // incidentSelector returns an incident selector.
-// The `!package` matches rules without a package specification.
+// The `!package` matches incidents without a package variable.
 func (r *Scope) incidentSelector() (selector string) {
 	predicate := func(in []string) (p string) {
 		var refs []string


### PR DESCRIPTION
Add support for incident selectors.  Users can filter in/out incidents based on packages. The `package` is reported as an Incident.Variables with key=`package`.
The `!package` and ` !(package)` syntax is used to match incidents without the _package_ variable.

Passes `--incident-selector` option as needed.

Test cases and expected selector:

| Case | Selector |
| --------- | ---------- |
| Empty |   |
|Included (only)| (!package\|\|package=a\|\|package=b) |
| Included and Excluded|(!package\|\|package=a\|\|package=b) && !(package=C\|\|package=D)|
|Excluded (only)|!(package\|\|package=C\|\|package=D)|
