### PR TITLE
:ghost: Go 1.20

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,9 @@
-GOBIN    ?= ${GOPATH}/bin
-IMG      ?= quay.io/konveyor/tackle2-addon-analyzer:latest
-CMD      ?= bin/addon
-AddonDir ?= /tmp/addon
+GOPATH    ?= $(HOME)/go
+GOBIN     ?= $(GOPATH)/bin
+IMG       ?= quay.io/konveyor/tackle2-addon-analyzer:latest
+CMD       ?= bin/addon
+AddonDir  ?= /tmp/addon
+GOIMPORTS = $(GOBIN)/goimports
 
 cmd: fmt vet
 	go build -ldflags="-w -s" -o ${CMD} github.com/konveyor/tackle2-addon-analyzer/cmd
@@ -17,9 +19,12 @@ run: cmd
 	$(eval cmd := $(abspath ${CMD}))
 	cd ${AddonDir};${cmd}
 
-fmt:
-	go fmt ./...
+fmt: $(GOIMPORTS)
+	$(GOIMPORTS) -w ./cmd
 
 vet:
-	go vet ./...
+	go vet ./cmd/...
 
+# Ensure goimports installed.
+$(GOIMPORTS):
+	go install golang.org/x/tools/cmd/goimports@latest

--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,12 @@ CMD       ?= bin/addon
 AddonDir  ?= /tmp/addon
 GOIMPORTS = $(GOBIN)/goimports
 
+PKG = ./cmd/... \
+      ./builder/...
+
+PKGDIR = $(subst /...,,$(PKG))
+
+
 cmd: fmt vet
 	go build -ldflags="-w -s" -o ${CMD} github.com/konveyor/tackle2-addon-analyzer/cmd
 
@@ -20,10 +26,10 @@ run: cmd
 	cd ${AddonDir};${cmd}
 
 fmt: $(GOIMPORTS)
-	$(GOIMPORTS) -w ./cmd
+	$(GOIMPORTS) -w $(PKGDIR)
 
 vet:
-	go vet ./cmd/...
+	go vet $(PKG)
 
 # Ensure goimports installed.
 $(GOIMPORTS):

--- a/builder/deps.go
+++ b/builder/deps.go
@@ -1,11 +1,12 @@
 package builder
 
 import (
+	"io"
+	"os"
+
 	output "github.com/konveyor/analyzer-lsp/output/v1/konveyor"
 	"github.com/konveyor/tackle2-hub/api"
 	"gopkg.in/yaml.v2"
-	"io"
-	"os"
 )
 
 // Deps builds dependencies.

--- a/builder/issue.go
+++ b/builder/issue.go
@@ -2,15 +2,16 @@ package builder
 
 import (
 	"fmt"
+	"io"
+	"net/url"
+	"os"
+
 	output "github.com/konveyor/analyzer-lsp/output/v1/konveyor"
 	hub "github.com/konveyor/tackle2-hub/addon"
 	"github.com/konveyor/tackle2-hub/api"
 	"go.lsp.dev/uri"
 	"gopkg.in/yaml.v2"
-	"io"
 	"k8s.io/utils/pointer"
-	"net/url"
-	"os"
 )
 
 var (

--- a/cmd/analyzer.go
+++ b/cmd/analyzer.go
@@ -1,9 +1,10 @@
 package main
 
 import (
+	"path"
+
 	"github.com/konveyor/tackle2-addon-analyzer/builder"
 	"github.com/konveyor/tackle2-addon/command"
-	"path"
 )
 
 type RuleError = builder.RuleError

--- a/cmd/cmd_test.go
+++ b/cmd/cmd_test.go
@@ -1,8 +1,9 @@
 package main
 
 import (
-	"github.com/onsi/gomega"
 	"testing"
+
+	"github.com/onsi/gomega"
 )
 
 func TestRuleSelector(t *testing.T) {

--- a/cmd/rules.go
+++ b/cmd/rules.go
@@ -1,17 +1,18 @@
 package main
 
 import (
+	"os"
+	"path"
+	"regexp"
+	"strconv"
+	"strings"
+
 	"github.com/konveyor/analyzer-lsp/parser"
 	"github.com/konveyor/tackle2-addon/command"
 	"github.com/konveyor/tackle2-addon/repository"
 	"github.com/konveyor/tackle2-hub/api"
 	"github.com/konveyor/tackle2-hub/nas"
 	"github.com/rogpeppe/go-internal/semver"
-	"os"
-	"path"
-	"regexp"
-	"strconv"
-	"strings"
 )
 
 type History = map[uint]byte

--- a/cmd/scope.go
+++ b/cmd/scope.go
@@ -1,8 +1,9 @@
 package main
 
 import (
-	"github.com/konveyor/tackle2-addon/command"
 	"strings"
+
+	"github.com/konveyor/tackle2-addon/command"
 )
 
 // Scope settings.
@@ -28,7 +29,6 @@ func (r *Scope) AddOptions(options *command.Options) (err error) {
 	return
 }
 
-//
 // incidentSelector returns an incident selector.
 // The injected `!package` matches incidents without a package variable.
 func (r *Scope) incidentSelector() (selector string) {

--- a/cmd/settings.go
+++ b/cmd/settings.go
@@ -2,15 +2,16 @@ package main
 
 import (
 	"errors"
-	"github.com/konveyor/analyzer-lsp/provider"
-	hub "github.com/konveyor/tackle2-hub/addon"
-	"github.com/konveyor/tackle2-hub/api"
-	"gopkg.in/yaml.v2"
 	"io"
 	"os"
 	"path"
 	"strconv"
 	"strings"
+
+	"github.com/konveyor/analyzer-lsp/provider"
+	hub "github.com/konveyor/tackle2-hub/addon"
+	"github.com/konveyor/tackle2-hub/api"
+	"gopkg.in/yaml.v2"
 )
 
 // Settings - provider settings file.

--- a/cmd/tagger.go
+++ b/cmd/tagger.go
@@ -1,10 +1,11 @@
 package main
 
 import (
-	"github.com/konveyor/tackle2-addon/command"
-	"github.com/konveyor/tackle2-hub/api"
 	"math/rand"
 	"regexp"
+
+	"github.com/konveyor/tackle2-addon/command"
+	"github.com/konveyor/tackle2-hub/api"
 )
 
 var TagExp = regexp.MustCompile("(.+)(=)(.+)")

--- a/go.mod
+++ b/go.mod
@@ -5,8 +5,8 @@ go 1.18
 require (
 	github.com/gin-gonic/gin v1.9.0
 	github.com/konveyor/analyzer-lsp v0.0.0-20230712145100-60dc2048444c
-	github.com/konveyor/tackle2-addon v0.3.0-rc.3.0.20240110200734-c6a793e8ee2c
-	github.com/konveyor/tackle2-hub v0.3.0-rc.2.0.20231219211826-f09d0b24c0e6
+	github.com/konveyor/tackle2-addon v0.3.1-0.20240124160358-3e62a6a55ee9
+	github.com/konveyor/tackle2-hub v0.3.1-0.20240123170057-e18a6547d4af
 	github.com/onsi/gomega v1.27.6
 	github.com/rogpeppe/go-internal v1.10.0
 	go.lsp.dev/uri v0.3.0

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/konveyor/tackle2-addon-analyzer
 
-go 1.18
+go 1.20
 
 require (
 	github.com/gin-gonic/gin v1.9.0

--- a/go.sum
+++ b/go.sum
@@ -145,12 +145,10 @@ github.com/klauspost/cpuid/v2 v2.0.9 h1:lgaqFMSdTdQYdZ04uHyN2d/eKdOMyi2YLSvlQIBF
 github.com/klauspost/cpuid/v2 v2.0.9/go.mod h1:FInQzS24/EEf25PyTYn52gqo7WaD8xa0213Md/qVLRg=
 github.com/konveyor/analyzer-lsp v0.0.0-20230712145100-60dc2048444c h1:DbOZO3cNmLBJ5Z6iXyl7Fb3ejWxicHAa3OHI++0KJd4=
 github.com/konveyor/analyzer-lsp v0.0.0-20230712145100-60dc2048444c/go.mod h1:+k6UreVv8ztI29/RyQN8/71AAmB0aWwQoWwZd3yR8sc=
-github.com/konveyor/tackle2-addon v0.3.0-rc.3.0.20240108180210-3de14a352bb8 h1:fc/YHGRf/q28lK5Z4W3l3NuLLWkOKe/S+nsH6R4IMgU=
-github.com/konveyor/tackle2-addon v0.3.0-rc.3.0.20240108180210-3de14a352bb8/go.mod h1:2ULCt88EGBK/N8bOCaerrUNlRw/VCZVXfXRBwmngNj4=
-github.com/konveyor/tackle2-addon v0.3.0-rc.3.0.20240110200734-c6a793e8ee2c h1:WKYq21yB2qQd314FBl26pXaUHOlYK69KXNuOD9hp3gE=
-github.com/konveyor/tackle2-addon v0.3.0-rc.3.0.20240110200734-c6a793e8ee2c/go.mod h1:2ULCt88EGBK/N8bOCaerrUNlRw/VCZVXfXRBwmngNj4=
-github.com/konveyor/tackle2-hub v0.3.0-rc.2.0.20231219211826-f09d0b24c0e6 h1:xPLwmNqA3QxVaqqnhF6v/T2ZMTCom2GcROD2BEJIHnQ=
-github.com/konveyor/tackle2-hub v0.3.0-rc.2.0.20231219211826-f09d0b24c0e6/go.mod h1:ZR4A0+Wp0H3QZkMohPnvZjxcolVORP3jdHV9Uwb/PoE=
+github.com/konveyor/tackle2-addon v0.3.1-0.20240124160358-3e62a6a55ee9 h1:aanIV3uhTFYKL876d6pgT+fiSQZ3VcdZ1Ej2f6HmEH0=
+github.com/konveyor/tackle2-addon v0.3.1-0.20240124160358-3e62a6a55ee9/go.mod h1:KAdekTXmr4TswWJyHRWaXGH+FeShMFaWTQi+JreWPSY=
+github.com/konveyor/tackle2-hub v0.3.1-0.20240123170057-e18a6547d4af h1:5sBsSoEi4TwFOzRaA87DGtXZOJHMEUH8WmBk+AfvJXY=
+github.com/konveyor/tackle2-hub v0.3.1-0.20240123170057-e18a6547d4af/go.mod h1:97Z3kWWmPERNl58XkpQkV/F+jnqNNDAVpL9m9XTZmdo=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
 github.com/kr/pretty v0.2.0/go.mod h1:ipq/a2n7PKx3OHsz4KJII5eveXtPO4qwEXGdVfWzfnI=
 github.com/kr/pretty v0.2.1/go.mod h1:ipq/a2n7PKx3OHsz4KJII5eveXtPO4qwEXGdVfWzfnI=


### PR DESCRIPTION
upgrade Go 1.20.
Replaces gofmt with goimports. Documentation claims it performs the same formatting plus manages/orders imports.
Added missing packages in Makefile.
Updated the go.mod and ran go mod tidy.

closes: #63 

NOT FOR 0.3.