### PR TITLE
:bug: Create intermediate path for resources stored as files.

### DIFF
--- a/cmd/injector.go
+++ b/cmd/injector.go
@@ -5,11 +5,13 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	pathlib "path"
 	"regexp"
 	"strings"
 
 	"github.com/konveyor/analyzer-lsp/provider"
 	"github.com/konveyor/tackle2-hub/api"
+	"github.com/konveyor/tackle2-hub/nas"
 )
 
 var (
@@ -180,6 +182,10 @@ func (r *ResourceInjector) add(resource *Resource, object any) (err error) {
 
 // write a resource field value to a file.
 func (r *ResourceInjector) write(path string, s string) (err error) {
+	err = nas.MkDir(pathlib.Dir(path), 0755)
+	if err != nil {
+		return
+	}
 	f, err := os.Create(path)
 	if err == nil {
 		_, err = f.Write([]byte(s))


### PR DESCRIPTION
The java extension CR defines:
```
    resources:
    - fields:
      - key: maven.settings.path
        name: settings
        path: /shared/creds/maven/settings.xml
      selector: identity:kind=maven
```
`/shared` exists but `creds/maven` needs to be created on demand.

Reported by CI as:
```
 "errors": [
      {
        "severity": "Error",
        "description": "open /shared/creds/maven/settings.xml: no such file or directory"
      }
    ],
```
