### PR TITLE
:bug: strip mvn:// prefix. This is a short-term workaround.

### DIFF
--- a/cmd/mode.go
+++ b/cmd/mode.go
@@ -115,7 +115,8 @@ func (r *Mode) getArtifact() (err error) {
 
 // mavenArtifact get maven artifact.
 func (r *Mode) mavenArtifact(application *api.Application, maven *repository.Maven) (err error) {
-	err = maven.FetchArtifact(application.Binary)
+	artifact := strings.TrimPrefix(application.Binary, "mvn://")
+	err = maven.FetchArtifact(artifact)
 	if err != nil {
 		return
 	}


### PR DESCRIPTION
Short-term workaround.
The UI merged a PR to prefixes the Application.Binary with "mvn://".  This PR is a fall-back until #97 can be merged which requires an analyzer patch to fix the builtin provider. 