### PR TITLE
:sparkles: Support succeeded with addon rule errors.

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -137,8 +137,9 @@ func main() {
 				if errors.As(err, &ruleErr) {
 					ruleErr.Report()
 					err = nil
+				} else {
+					return
 				}
-				return
 			}
 			//
 			// Facts
@@ -151,7 +152,6 @@ func main() {
 				return
 			}
 		}
-
 		//
 		// Tags.
 		if d.Tagger.Enabled {

--- a/go.mod
+++ b/go.mod
@@ -14,6 +14,8 @@ require (
 	k8s.io/utils v0.0.0-20220728103510-ee6ede2d64ed
 )
 
+replace github.com/konveyor/tackle2-hub => github.com/jortel/tackle2-hub v0.0.0-20240701201116-5edf43fe89da
+
 require (
 	github.com/Nerzal/gocloak/v10 v10.0.1 // indirect
 	github.com/PaesslerAG/gval v1.2.2 // indirect

--- a/go.mod
+++ b/go.mod
@@ -6,15 +6,13 @@ require (
 	github.com/gin-gonic/gin v1.9.1
 	github.com/konveyor/analyzer-lsp v0.4.0-alpha.1.0.20240603131628-bc4ff29956a2
 	github.com/konveyor/tackle2-addon v0.4.0-alpha.1
-	github.com/konveyor/tackle2-hub v0.4.1-0.20240611123927-c28822efd364
+	github.com/konveyor/tackle2-hub v0.5.0-alpha.2.0.20240702184924-4648a9c03ecc
 	github.com/onsi/gomega v1.27.6
 	github.com/rogpeppe/go-internal v1.10.0
 	go.lsp.dev/uri v0.3.0
 	gopkg.in/yaml.v2 v2.4.0
 	k8s.io/utils v0.0.0-20220728103510-ee6ede2d64ed
 )
-
-replace github.com/konveyor/tackle2-hub => github.com/jortel/tackle2-hub v0.0.0-20240701201116-5edf43fe89da
 
 require (
 	github.com/Nerzal/gocloak/v10 v10.0.1 // indirect

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/gin-gonic/gin v1.9.1
 	github.com/konveyor/analyzer-lsp v0.4.0-alpha.1.0.20240603131628-bc4ff29956a2
 	github.com/konveyor/tackle2-addon v0.4.0-alpha.1
-	github.com/konveyor/tackle2-hub v0.5.0-alpha.2.0.20240702184924-4648a9c03ecc
+	github.com/konveyor/tackle2-hub v0.5.0-beta.1
 	github.com/onsi/gomega v1.27.6
 	github.com/rogpeppe/go-internal v1.10.0
 	go.lsp.dev/uri v0.3.0

--- a/go.sum
+++ b/go.sum
@@ -128,6 +128,8 @@ github.com/jinzhu/now v1.1.5 h1:/o9tlHleP7gOFmsnYNz3RGnqzefHA47wQpKrrdTIwXQ=
 github.com/jinzhu/now v1.1.5/go.mod h1:d3SSVoowX0Lcu0IBviAWJpolVfI5UJVZZ7cO71lE/z8=
 github.com/jortel/go-utils v0.1.2 h1:R0TcGRCcwoL793CymcKC5AF9idWXT2cR6eQ2xpBUsoI=
 github.com/jortel/go-utils v0.1.2/go.mod h1:sl6vav63ODI0sUfSz8e0pImNmCVFnVsuOFhZmwe9GDk=
+github.com/jortel/tackle2-hub v0.0.0-20240701201116-5edf43fe89da h1:aly+rezDXDnitfJbYJfrR4vsdbyk/+N5GSprKyjh3Q8=
+github.com/jortel/tackle2-hub v0.0.0-20240701201116-5edf43fe89da/go.mod h1:5c5A3i/oARdUp1yo+iYJFFvsIlsbsVGBZT7/CQji9YY=
 github.com/josharian/intern v1.0.0 h1:vlS4z54oSdjm0bgjRigI+G1HpF+tI+9rE5LLzOg8HmY=
 github.com/josharian/intern v1.0.0/go.mod h1:5DoeVV0s6jJacbCEi61lwdGj/aVlrQvzHFFd8Hwg//Y=
 github.com/json-iterator/go v1.1.12 h1:PV8peI4a0ysnczrg+LtxykD8LfKY9ML6u2jnxaEnrnM=
@@ -141,8 +143,6 @@ github.com/konveyor/analyzer-lsp v0.4.0-alpha.1.0.20240603131628-bc4ff29956a2 h1
 github.com/konveyor/analyzer-lsp v0.4.0-alpha.1.0.20240603131628-bc4ff29956a2/go.mod h1:GXkSykQ84oE1SyMvFko9s9wRn/FMdl4efLLWSjMX2nU=
 github.com/konveyor/tackle2-addon v0.4.0-alpha.1 h1:YgkA3fUAFeaV5K22WpcnxvdhWJxvE/y+Vqn6Z8NvPMs=
 github.com/konveyor/tackle2-addon v0.4.0-alpha.1/go.mod h1:d5jsa9qR1PKF8J7ZZcxfg9K+KFScu5YJQrp1Yzhjoss=
-github.com/konveyor/tackle2-hub v0.4.1-0.20240611123927-c28822efd364 h1:uOOgOM5n7X8vNhUdpKfAiAF70NfAU0OtTGlSx53QWyg=
-github.com/konveyor/tackle2-hub v0.4.1-0.20240611123927-c28822efd364/go.mod h1:5c5A3i/oARdUp1yo+iYJFFvsIlsbsVGBZT7/CQji9YY=
 github.com/kr/pretty v0.2.0/go.mod h1:ipq/a2n7PKx3OHsz4KJII5eveXtPO4qwEXGdVfWzfnI=
 github.com/kr/pretty v0.2.1/go.mod h1:ipq/a2n7PKx3OHsz4KJII5eveXtPO4qwEXGdVfWzfnI=
 github.com/kr/pretty v0.3.1 h1:flRD4NNwYAUpkphVc1HcthR4KEIFJ65n8Mw5qdRn3LE=

--- a/go.sum
+++ b/go.sum
@@ -128,8 +128,6 @@ github.com/jinzhu/now v1.1.5 h1:/o9tlHleP7gOFmsnYNz3RGnqzefHA47wQpKrrdTIwXQ=
 github.com/jinzhu/now v1.1.5/go.mod h1:d3SSVoowX0Lcu0IBviAWJpolVfI5UJVZZ7cO71lE/z8=
 github.com/jortel/go-utils v0.1.2 h1:R0TcGRCcwoL793CymcKC5AF9idWXT2cR6eQ2xpBUsoI=
 github.com/jortel/go-utils v0.1.2/go.mod h1:sl6vav63ODI0sUfSz8e0pImNmCVFnVsuOFhZmwe9GDk=
-github.com/jortel/tackle2-hub v0.0.0-20240701201116-5edf43fe89da h1:aly+rezDXDnitfJbYJfrR4vsdbyk/+N5GSprKyjh3Q8=
-github.com/jortel/tackle2-hub v0.0.0-20240701201116-5edf43fe89da/go.mod h1:5c5A3i/oARdUp1yo+iYJFFvsIlsbsVGBZT7/CQji9YY=
 github.com/josharian/intern v1.0.0 h1:vlS4z54oSdjm0bgjRigI+G1HpF+tI+9rE5LLzOg8HmY=
 github.com/josharian/intern v1.0.0/go.mod h1:5DoeVV0s6jJacbCEi61lwdGj/aVlrQvzHFFd8Hwg//Y=
 github.com/json-iterator/go v1.1.12 h1:PV8peI4a0ysnczrg+LtxykD8LfKY9ML6u2jnxaEnrnM=
@@ -143,6 +141,8 @@ github.com/konveyor/analyzer-lsp v0.4.0-alpha.1.0.20240603131628-bc4ff29956a2 h1
 github.com/konveyor/analyzer-lsp v0.4.0-alpha.1.0.20240603131628-bc4ff29956a2/go.mod h1:GXkSykQ84oE1SyMvFko9s9wRn/FMdl4efLLWSjMX2nU=
 github.com/konveyor/tackle2-addon v0.4.0-alpha.1 h1:YgkA3fUAFeaV5K22WpcnxvdhWJxvE/y+Vqn6Z8NvPMs=
 github.com/konveyor/tackle2-addon v0.4.0-alpha.1/go.mod h1:d5jsa9qR1PKF8J7ZZcxfg9K+KFScu5YJQrp1Yzhjoss=
+github.com/konveyor/tackle2-hub v0.5.0-alpha.2.0.20240702184924-4648a9c03ecc h1:0a5dMhslS3buC5RMg7AukP7eXCZk3sE0PA09bDl7/U8=
+github.com/konveyor/tackle2-hub v0.5.0-alpha.2.0.20240702184924-4648a9c03ecc/go.mod h1:5c5A3i/oARdUp1yo+iYJFFvsIlsbsVGBZT7/CQji9YY=
 github.com/kr/pretty v0.2.0/go.mod h1:ipq/a2n7PKx3OHsz4KJII5eveXtPO4qwEXGdVfWzfnI=
 github.com/kr/pretty v0.2.1/go.mod h1:ipq/a2n7PKx3OHsz4KJII5eveXtPO4qwEXGdVfWzfnI=
 github.com/kr/pretty v0.3.1 h1:flRD4NNwYAUpkphVc1HcthR4KEIFJ65n8Mw5qdRn3LE=

--- a/go.sum
+++ b/go.sum
@@ -141,8 +141,8 @@ github.com/konveyor/analyzer-lsp v0.4.0-alpha.1.0.20240603131628-bc4ff29956a2 h1
 github.com/konveyor/analyzer-lsp v0.4.0-alpha.1.0.20240603131628-bc4ff29956a2/go.mod h1:GXkSykQ84oE1SyMvFko9s9wRn/FMdl4efLLWSjMX2nU=
 github.com/konveyor/tackle2-addon v0.4.0-alpha.1 h1:YgkA3fUAFeaV5K22WpcnxvdhWJxvE/y+Vqn6Z8NvPMs=
 github.com/konveyor/tackle2-addon v0.4.0-alpha.1/go.mod h1:d5jsa9qR1PKF8J7ZZcxfg9K+KFScu5YJQrp1Yzhjoss=
-github.com/konveyor/tackle2-hub v0.5.0-alpha.2.0.20240702184924-4648a9c03ecc h1:0a5dMhslS3buC5RMg7AukP7eXCZk3sE0PA09bDl7/U8=
-github.com/konveyor/tackle2-hub v0.5.0-alpha.2.0.20240702184924-4648a9c03ecc/go.mod h1:5c5A3i/oARdUp1yo+iYJFFvsIlsbsVGBZT7/CQji9YY=
+github.com/konveyor/tackle2-hub v0.5.0-beta.1 h1:wauq0BdSFd6Uq78TUWbjNMHBv/MVyYruvhuQSKUV8OM=
+github.com/konveyor/tackle2-hub v0.5.0-beta.1/go.mod h1:5c5A3i/oARdUp1yo+iYJFFvsIlsbsVGBZT7/CQji9YY=
 github.com/kr/pretty v0.2.0/go.mod h1:ipq/a2n7PKx3OHsz4KJII5eveXtPO4qwEXGdVfWzfnI=
 github.com/kr/pretty v0.2.1/go.mod h1:ipq/a2n7PKx3OHsz4KJII5eveXtPO4qwEXGdVfWzfnI=
 github.com/kr/pretty v0.3.1 h1:flRD4NNwYAUpkphVc1HcthR4KEIFJ65n8Mw5qdRn3LE=


### PR DESCRIPTION
Errors listed by the analyzer in the report (errors array) are reported by the addon as TaskReport errors but the TaskReport.Status is not set to `Failed`.

Requires: https://github.com/konveyor/tackle2-hub/pull/681