### PR TITLE
Revert ":bug: Use tag source from Tagger"

### DIFF
--- a/cmd/tagger.go
+++ b/cmd/tagger.go
@@ -110,7 +110,7 @@ func (r *Tagger) ensureTags(catMap map[string]uint, tags []string) (tagIds []uin
 // ensureAssociated ensure wanted tags are associated.
 func (r *Tagger) ensureAssociated(appID uint, wanted []uint) (err error) {
 	tags := addon.Application.Tags(appID)
-	tags.Source(r.Source)
+	tags.Source(Source)
 	err = tags.Replace(wanted)
 	return
 }


### PR DESCRIPTION
Reverts konveyor/tackle2-addon-analyzer#104