### PR TITLE
:sparkles: Attach analyzer report when verbosity > 0.

### DIFF
--- a/cmd/analyzer.go
+++ b/cmd/analyzer.go
@@ -27,6 +27,17 @@ func (r *Analyzer) Run() (b *builder.Issues, err error) {
 	}
 	b = &builder.Issues{Path: output}
 	err = cmd.Run()
+	if err != nil {
+		return
+	}
+	if Verbosity > 0 {
+		f, pErr := addon.File.Post(output)
+		if pErr != nil {
+			err = pErr
+			return
+		}
+		addon.Attach(f)
+	}
 	return
 }
 


### PR DESCRIPTION
Attach analyzer report when verbosity > 0 to better support troubleshooting.

https://issues.redhat.com/browse/MTA-1457