### PR TITLE
:bug: Report violations for ruleset with errors.

### DIFF
--- a/builder/deps.go
+++ b/builder/deps.go
@@ -40,7 +40,7 @@ func (b *Deps) Write(writer io.Writer) (err error) {
 	encoder := yaml.NewEncoder(writer)
 	for _, p := range input {
 		for _, d := range p.Dependencies {
-			_ = encoder.Encode(
+			err = encoder.Encode(
 				&api.TechDependency{
 					Provider: p.Provider,
 					Indirect: d.Indirect,
@@ -49,6 +49,9 @@ func (b *Deps) Write(writer io.Writer) (err error) {
 					SHA:      d.ResolvedIdentifier,
 					Labels:   d.Labels,
 				})
+			if err != nil {
+				return
+			}
 		}
 	}
 	return


### PR DESCRIPTION
In support of succeeded-with-errors, the addon should report issues (violations) even when the ruleset reports errors.

Also fixes duplicate rule errors added to the Task.Errors.