### PR TITLE
:bug: Report ruleErr outside of builder stream.

### DIFF
--- a/builder/issue.go
+++ b/builder/issue.go
@@ -26,6 +26,11 @@ type Issues struct {
 	Path    string
 }
 
+// RuleErr returns the rule error.
+func (b *Issues) RuleErr() (r *RuleError) {
+	return &b.ruleErr
+}
+
 // Reader returns a reader.
 func (b *Issues) Reader() (r io.Reader) {
 	r, w := io.Pipe()
@@ -92,13 +97,6 @@ func (b *Issues) Write(writer io.Writer) (err error) {
 				return
 			}
 		}
-	}
-	if err != nil {
-		return
-	}
-	if b.ruleErr.NotEmpty() {
-		err = &b.ruleErr
-		return
 	}
 	return
 }
@@ -178,6 +176,9 @@ func (e *RuleError) NotEmpty() (b bool) {
 }
 
 func (e *RuleError) Report() {
+	if len(e.items) == 0 {
+		return
+	}
 	var errors []api.TaskError
 	for ruleid, err := range e.items {
 		errors = append(

--- a/builder/issue.go
+++ b/builder/issue.go
@@ -26,8 +26,8 @@ type Issues struct {
 	Path    string
 }
 
-// RuleErr returns the rule error.
-func (b *Issues) RuleErr() (r *RuleError) {
+// RuleError returns the rule error.
+func (b *Issues) RuleError() (r *RuleError) {
 	return &b.ruleErr
 }
 

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -133,7 +133,9 @@ func main() {
 				return
 			}
 			addon.Activity("Analysis reported. duration: %s", time.Since(mark))
-			ruleErr := issues.RuleErr()
+			//
+			// RuleError
+			ruleErr := issues.RuleError()
 			ruleErr.Report()
 			//
 			// Facts

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"errors"
 	"os"
 	"path"
 	"time"
@@ -130,17 +129,12 @@ func main() {
 				binding.MIMEYAML,
 				issues.Reader(),
 				deps.Reader())
-			if err == nil {
-				addon.Activity("Analysis reported. duration: %s", time.Since(mark))
-			} else {
-				ruleErr := &RuleError{}
-				if errors.As(err, &ruleErr) {
-					ruleErr.Report()
-					err = nil
-				} else {
-					return
-				}
+			if err != nil {
+				return
 			}
+			addon.Activity("Analysis reported. duration: %s", time.Since(mark))
+			ruleErr := issues.RuleErr()
+			ruleErr.Report()
 			//
 			// Facts
 			facts := addon.Application.Facts(application.ID)


### PR DESCRIPTION
To support succeeded with errors, the RuleError cannot be returned in the builder stream because it is interpreted as a streaming error by the multi-part form send.

related: https://github.com/konveyor/tackle2-hub/pull/729

closes #114 