### PR TITLE
:bug: Fix Targets (Rulesets) with repositories.

### DIFF
--- a/cmd/rules.go
+++ b/cmd/rules.go
@@ -450,7 +450,7 @@ func (r *Labels) extract(paths []string) (err error) {
 		return
 	}
 	for _, ruleDir := range paths {
-		addon.Activity("Extracting labels: %d", ruleDir)
+		addon.Activity("[RULE] Extract labels: %s", ruleDir)
 		err = filepath.Walk(ruleDir, inspect)
 		if err != nil {
 			return

--- a/cmd/rules.go
+++ b/cmd/rules.go
@@ -102,6 +102,7 @@ func (r *Rules) addFiles() (err error) {
 	}
 	for _, ent := range entries {
 		if ent.Name() == parser.RULE_SET_GOLDEN_FILE_NAME {
+			r.repositories = append(r.repositories, ruleDir)
 			r.append(ruleDir)
 			return
 		}
@@ -449,6 +450,7 @@ func (r *Labels) extract(paths []string) (err error) {
 		return
 	}
 	for _, ruleDir := range paths {
+		addon.Activity("Extracting labels: %d", ruleDir)
 		err = filepath.Walk(ruleDir, inspect)
 		if err != nil {
 			return

--- a/cmd/rules.go
+++ b/cmd/rules.go
@@ -15,7 +15,7 @@ import (
 	"github.com/konveyor/tackle2-hub/api"
 	"github.com/konveyor/tackle2-hub/nas"
 	"github.com/rogpeppe/go-internal/semver"
-	"gopkg.in/yaml.v2"
+	"gopkg.in/yaml.v3"
 )
 
 const (

--- a/cmd/rules.go
+++ b/cmd/rules.go
@@ -33,12 +33,12 @@ var LvRegex = regexp.MustCompile(`(\D+)(\d(?:[\d\.]*\d)?)([\+-])?$`)
 
 // Rules settings.
 type Rules struct {
-	Path          string          `json:"path"`
-	Repository    *api.Repository `json:"repository"`
-	Identity      *api.Ref        `json:"identity"`
-	Labels        Labels          `json:"labels"`
-	extractLabels []string
-	rules         []string
+	Path         string          `json:"path"`
+	Repository   *api.Repository `json:"repository"`
+	Identity     *api.Ref        `json:"identity"`
+	Labels       Labels          `json:"labels"`
+	repositories []string
+	rules        []string
 }
 
 // Build assets.
@@ -59,7 +59,7 @@ func (r *Rules) Build() (err error) {
 	if err != nil {
 		return
 	}
-	err = r.Labels.extract(r.extractLabels)
+	err = r.Labels.extract(r.repositories)
 	if err != nil {
 		return
 	}
@@ -113,7 +113,7 @@ func (r *Rules) addFiles() (err error) {
 		n++
 	}
 	if n > 0 {
-		r.extractLabels = append(r.extractLabels, ruleDir)
+		r.repositories = append(r.repositories, ruleDir)
 	}
 	return
 }
@@ -244,7 +244,7 @@ func (r *Rules) addRuleSetRepository(ruleset *api.RuleSet) (err error) {
 		return
 	}
 	ruleDir := path.Join(rootDir, ruleset.Repository.Path)
-	r.extractLabels = append(r.extractLabels, ruleDir)
+	r.repositories = append(r.repositories, ruleDir)
 	r.append(ruleDir)
 	return
 }
@@ -277,7 +277,7 @@ func (r *Rules) addRepository() (err error) {
 		return
 	}
 	ruleDir := path.Join(rootDir, r.Repository.Path)
-	r.extractLabels = append(r.extractLabels, ruleDir)
+	r.repositories = append(r.repositories, ruleDir)
 	r.append(ruleDir)
 	return
 }

--- a/cmd/rules.go
+++ b/cmd/rules.go
@@ -391,6 +391,7 @@ func (r *Labels) extract(paths []string) (err error) {
 	inspect := func(p string, info fs.FileInfo, wErr error) (_ error) {
 		var err error
 		if wErr != nil || info.IsDir() {
+			addon.Log.Error(wErr, p)
 			return
 		}
 		switch strings.ToUpper(path.Ext(p)) {
@@ -469,13 +470,17 @@ func (r *Labels) extract(paths []string) (err error) {
 // addIncluded uniquely adds labels to the included set.
 func (r *Labels) addIncluded(extracted ...string) (added []string) {
 	for _, s := range extracted {
+		found := false
 		for _, included := range r.Included {
 			if included == s {
-				return
+				found = true
+				break
 			}
 		}
-		added = append(added, s)
-		r.Included = append(r.Included, s)
+		if !found {
+			added = append(added, s)
+			r.Included = append(r.Included, s)
+		}
 	}
 	return
 }


### PR DESCRIPTION
https://issues.redhat.com/browse/MTA-3330

A custom target that references a repository will be created with a related `RuleSet`. A repository may be defined on the ruleSet. An analysis task defines _included_ labels which determine which rulesets are pulled (downloaded) from the hub.  Since ruleSets that reference repositories do not have labels, the addon did not know to download it and clone the repository.

Solution:
The new rules.ruleSets will be used to pass a list of RuleSet (refs) selected by the user (by selecting targets).  Each will be be unconditionally fetched by the addon.

For each ruleset with a repository the addon will:
- clone the repository
- update .yaml files - replacing the `labels` element with `konveyor.io/include=always`.

related: https://github.com/konveyor/tackle2-ui/pull/2034