### PR TITLE
:bug: Fix transaction deadlock in dep builder.

### DIFF
--- a/builder/deps.go
+++ b/builder/deps.go
@@ -63,7 +63,7 @@ func (b *Deps) read() (input []output.DepsFlatItem, err error) {
 	f, err := os.Open(b.Path)
 	if err != nil {
 		if os.IsNotExist(err) {
-			addon.Activity(err.Error())
+			addon.Log.Info(err.Error())
 			err = nil
 		}
 		return


### PR DESCRIPTION
closes #121 

The `addon.Activity()` reports addon activity which is appended to the TaskReport.Activity using a PUT.  This will briefly acquire a DB transaction (in the hub).
The builder MUST not report activity because the addon already has a transaction open in the hub because of the POST of the analysis report.  This creates a DEADLOCK.

**There is a race-condition**: This only happens when the hub begins the transaction before the dep writer reports the dep.yaml not found.  I can force this by adding a sleep to where the writer reports this.  I suspect the hub can be busy enough with UI GET requests to delay it beginning the analysis POST until after the builder reports the file not found.

Flow:
```
addon                    hub
   | post analysis ----- >|  
   |                      | begin tx
   | writer <-------------| read 
   | writer: put task --> | begin tx (deadlock)
```

Regression added PR #97 