### PR TITLE
:bug: Run the shim on each directory.

### DIFF
--- a/cmd/rules.go
+++ b/cmd/rules.go
@@ -318,8 +318,10 @@ func (r *Rules) ensureRuleSet() (err error) {
 			_ = f.Close()
 		}()
 		en := yaml.NewEncoder(f)
+		p = path.Dir(p)
+		p = strings.TrimPrefix(p, RuleDir)
 		part := strings.Split(p, "/")
-		name := strings.Join(part, "-")
+		name := strings.Join(part[1:], "-")
 		err = en.Encode(map[string]any{"name": name})
 		return
 	}

--- a/cmd/rules.go
+++ b/cmd/rules.go
@@ -330,7 +330,7 @@ func (r *Rules) ensureRuleSet() (err error) {
 			continue
 		}
 		if os.IsNotExist(err) {
-			err = create(p)
+			err = create(ruleDir)
 			if err != nil {
 				return
 			}

--- a/cmd/rules.go
+++ b/cmd/rules.go
@@ -304,14 +304,22 @@ func (r *Rules) addSelector(options *command.Options) (err error) {
 }
 
 // convert windup rules.
+// Run the shim on all ruleset directories.
 func (r *Rules) convert() (err error) {
-	cmd := command.New("/usr/bin/windup-shim")
-	cmd.Options.Add("convert")
-	cmd.Options.Add("--outputdir", RuleDir)
-	cmd.Options.Add(RuleDir)
-	err = cmd.Run()
-	if err != nil {
-		return
+	var st os.FileInfo
+	for _, ruleDir := range r.rules {
+		st, err = os.Stat(ruleDir)
+		if !st.IsDir() {
+			continue
+		}
+		cmd := command.New("/usr/bin/windup-shim")
+		cmd.Options.Add("convert")
+		cmd.Options.Add("--outputdir", ruleDir)
+		cmd.Options.Add(ruleDir)
+		err = cmd.Run()
+		if err != nil {
+			return
+		}
 	}
 	return
 }

--- a/cmd/rules.go
+++ b/cmd/rules.go
@@ -318,7 +318,9 @@ func (r *Rules) ensureRuleSet() (err error) {
 			_ = f.Close()
 		}()
 		en := yaml.NewEncoder(f)
-		err = en.Encode(map[string]any{"name": path.Base(p)})
+		part := strings.Split(p, "/")
+		name := strings.Join(part, "-")
+		err = en.Encode(map[string]any{"name": name})
 		return
 	}
 	for _, ruleDir := range r.rules {
@@ -330,7 +332,7 @@ func (r *Rules) ensureRuleSet() (err error) {
 			continue
 		}
 		if os.IsNotExist(err) {
-			err = create(ruleDir)
+			err = create(p)
 			if err != nil {
 				return
 			}

--- a/cmd/rules.go
+++ b/cmd/rules.go
@@ -57,6 +57,10 @@ func (r *Rules) Build() (err error) {
 	if err != nil {
 		return
 	}
+	err = r.ensureRuleSet()
+	if err != nil {
+		return
+	}
 	err = r.Labels.injectAlways(r.repositories)
 	if err != nil {
 		return
@@ -94,26 +98,8 @@ func (r *Rules) addFiles() (err error) {
 	if err != nil {
 		return
 	}
-	entries, err := os.ReadDir(ruleDir)
-	if err != nil {
-		return
-	}
-	for _, ent := range entries {
-		if ent.Name() == parser.RULE_SET_GOLDEN_FILE_NAME {
-			r.repositories = append(r.repositories, ruleDir)
-			r.append(ruleDir)
-			return
-		}
-	}
-	n := 0
-	for _, ent := range entries {
-		p := path.Join(ruleDir, ent.Name())
-		r.append(p)
-		n++
-	}
-	if n > 0 {
-		r.repositories = append(r.repositories, ruleDir)
-	}
+	r.rules = append(r.rules, ruleDir)
+	r.repositories = append(r.repositories, ruleDir)
 	return
 }
 
@@ -205,22 +191,21 @@ func (r *Rules) addRules(ruleset *api.RuleSet) (err error) {
 		return
 	}
 	n := len(ruleset.Rules)
+	if n < 1 {
+		return
+	}
+	r.rules = append(r.rules, ruleDir)
 	for _, ruleset := range ruleset.Rules {
-		fileRef := ruleset.File
-		if fileRef == nil {
+		file := ruleset.File
+		if file == nil {
 			continue
 		}
-		path := path.Join(ruleDir, fileRef.Name)
-		err = addon.File.Get(ruleset.File.ID, path)
+		err = addon.File.Get(
+			ruleset.File.ID,
+			path.Join(ruleDir, file.Name))
 		if err != nil {
 			break
 		}
-		if n == 1 {
-			r.append(path)
-		}
-	}
-	if n > 1 {
-		r.append(ruleDir)
 	}
 	return
 }
@@ -256,7 +241,7 @@ func (r *Rules) addRuleSetRepository(ruleset *api.RuleSet) (err error) {
 	}
 	ruleDir := path.Join(rootDir, ruleset.Repository.Path)
 	r.repositories = append(r.repositories, ruleDir)
-	r.append(ruleDir)
+	r.rules = append(r.rules, ruleDir)
 	return
 }
 
@@ -289,7 +274,7 @@ func (r *Rules) addRepository() (err error) {
 	}
 	ruleDir := path.Join(rootDir, r.Repository.Path)
 	r.repositories = append(r.repositories, ruleDir)
-	r.append(ruleDir)
+	r.rules = append(r.rules, ruleDir)
 	return
 }
 
@@ -306,12 +291,9 @@ func (r *Rules) addSelector(options *command.Options) (err error) {
 // convert windup rules.
 // Run the shim on all ruleset directories.
 func (r *Rules) convert() (err error) {
-	var st os.FileInfo
+
 	for _, ruleDir := range r.rules {
-		st, err = os.Stat(ruleDir)
-		if !st.IsDir() {
-			continue
-		}
+
 		cmd := command.New("/usr/bin/windup-shim")
 		cmd.Options.Add("convert")
 		cmd.Options.Add("--outputdir", ruleDir)
@@ -324,19 +306,39 @@ func (r *Rules) convert() (err error) {
 	return
 }
 
-// append path.
-func (r *Rules) append(p string) {
-	for i := range r.rules {
-		if r.rules[i] == p {
+// ensureRuleSet ensures each ruleDir in rules
+// contains a ruleset.yaml file.
+func (r *Rules) ensureRuleSet() (err error) {
+	create := func(p string) (err error) {
+		f, err := os.Create(p)
+		if err != nil {
+			return
+		}
+		defer func() {
+			_ = f.Close()
+		}()
+		en := yaml.NewEncoder(f)
+		err = en.Encode(map[string]any{"name": path.Base(p)})
+		return
+	}
+	for _, ruleDir := range r.rules {
+		p := path.Join(
+			ruleDir,
+			parser.RULE_SET_GOLDEN_FILE_NAME)
+		_, err = os.Stat(p)
+		if err == nil {
+			continue
+		}
+		if os.IsNotExist(err) {
+			err = create(p)
+			if err != nil {
+				return
+			}
+		} else {
 			return
 		}
 	}
-	switch strings.ToUpper(path.Ext(p)) {
-	case "",
-		".YAML",
-		".YML":
-		r.rules = append(r.rules, p)
-	}
+	return
 }
 
 // Labels collection.


### PR DESCRIPTION
Ensure each _ruleDir_ (`--rules`) contains a `ruleset.yaml`.
Run the shim on all _ruleDir_.  This includes rules/files which contains uploaded individual rule files.
This is needed because the shim creates converted files in the root of the output dir.

https://issues.redhat.com/browse/MTA-3163
https://issues.redhat.com/browse/MTA-3330