### PR TITLE
:sparkles: Adding maven global settings for selecting correct cache dir

### DIFF
--- a/cmd/analyzer.go
+++ b/cmd/analyzer.go
@@ -86,6 +86,10 @@ func (r *Analyzer) options(output, depOutput string) (options command.Options, e
 	if err != nil {
 		return
 	}
+	err = r.MavenSettings.UpdateSettings(settings)
+	if err != nil {
+		return
+	}
 	err = settings.Write()
 	if err != nil {
 		return

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -51,6 +51,8 @@ type Data struct {
 	Rules Rules `json:"rules"`
 	// Tagger options.
 	Tagger Tagger `json:"tagger"`
+	// MavenSettings options
+	MavenSettings MavenGlobalSettings `json:"mavenSettings,omitempty"`
 }
 
 // main
@@ -88,6 +90,11 @@ func main() {
 			return
 		}
 		//
+		// Create the maven user settings.
+		d.MavenSettings = MavenGlobalSettings{
+			MavenRepoLocation: M2Dir,
+			SharedDir:         SharedDir,
+		}
 		// SSH
 		agent := ssh.Agent{}
 		err = agent.Start()
@@ -101,6 +108,10 @@ func main() {
 			return
 		}
 		err = d.Rules.Build()
+		if err != nil {
+			return
+		}
+		err = d.MavenSettings.Build()
 		if err != nil {
 			return
 		}

--- a/cmd/maven_settings.go
+++ b/cmd/maven_settings.go
@@ -1,0 +1,49 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"path"
+)
+
+// Settings - provider settings file.
+type MavenGlobalSettings struct {
+	MavenRepoLocation string
+	SharedDir         string
+}
+
+const GLOBAL_MAVEN_SETTINGS_KEY = "mavenGlobalSettings"
+const GLOBAL_MAVEN_FILE_NAME = "globalSettings.xml"
+
+func (m *MavenGlobalSettings) Build() (err error) {
+	fileContentTemplate := `
+<settings xmlns="http://maven.apache.org/SETTINGS/1.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0 https://maven.apache.org/xsd/settings-1.0.0.xsd">
+  <localRepository>%s</localRepository>
+</settings>
+	`
+	path := path.Join(m.SharedDir, GLOBAL_MAVEN_FILE_NAME)
+	f, err := os.Create(path)
+	if err != nil {
+		return
+	}
+	defer func() {
+		_ = f.Close()
+	}()
+	_, err = f.Write([]byte(fmt.Sprintf(fileContentTemplate, m.MavenRepoLocation)))
+	return
+}
+
+// Function to update the settings with the maven global config
+// to use the correct directory for the maven cache.
+func (m *MavenGlobalSettings) UpdateSettings(settings *Settings) (err error) {
+	for _, config := range settings.content {
+		for _, initConfig := range config.InitConfig {
+			if initConfig.ProviderSpecificConfig == nil {
+				initConfig.ProviderSpecificConfig = map[string]interface{}{}
+			}
+			initConfig.ProviderSpecificConfig[GLOBAL_MAVEN_SETTINGS_KEY] = path.Join(m.SharedDir, GLOBAL_MAVEN_FILE_NAME)
+		}
+	}
+	return nil
+}

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.20
 require (
 	github.com/gin-gonic/gin v1.9.1
 	github.com/konveyor/analyzer-lsp v0.4.0-alpha.1.0.20240603131628-bc4ff29956a2
-	github.com/konveyor/tackle2-addon v0.6.0-alpha.1.0.20241010185506-67652f48f2f2
+	github.com/konveyor/tackle2-addon v0.6.0-alpha.2
 	github.com/konveyor/tackle2-hub v0.5.1-0.20240926152344-e15a8a4fbf23
 	github.com/onsi/gomega v1.27.6
 	github.com/rogpeppe/go-internal v1.10.0

--- a/go.sum
+++ b/go.sum
@@ -144,6 +144,8 @@ github.com/konveyor/analyzer-lsp v0.4.0-alpha.1.0.20240603131628-bc4ff29956a2 h1
 github.com/konveyor/analyzer-lsp v0.4.0-alpha.1.0.20240603131628-bc4ff29956a2/go.mod h1:GXkSykQ84oE1SyMvFko9s9wRn/FMdl4efLLWSjMX2nU=
 github.com/konveyor/tackle2-addon v0.6.0-alpha.1.0.20241010185506-67652f48f2f2 h1:xmH1Uw9mGajwXOSsyP3D9j+mHO+7/ukZOyqKKTqjFg0=
 github.com/konveyor/tackle2-addon v0.6.0-alpha.1.0.20241010185506-67652f48f2f2/go.mod h1:1cHTnmMGtYzv0GIMiyEMPkJe+hOlzbhxwRal5e7Mog0=
+github.com/konveyor/tackle2-addon v0.6.0-alpha.2 h1:1WV7D9KwaVYG1xMKuRuSc84+ZVBWcPm1L+kednlW1zA=
+github.com/konveyor/tackle2-addon v0.6.0-alpha.2/go.mod h1:1cHTnmMGtYzv0GIMiyEMPkJe+hOlzbhxwRal5e7Mog0=
 github.com/konveyor/tackle2-hub v0.5.1-0.20240926152344-e15a8a4fbf23 h1:EnSIrmEte86RvQx8/QsCnm/Wo/F+z0NMowTdoZJpUhc=
 github.com/konveyor/tackle2-hub v0.5.1-0.20240926152344-e15a8a4fbf23/go.mod h1:PeqkGgjIbCjaK/zudHGcBG4jB3Wbyi+lAIDLUjgjbMI=
 github.com/kr/pretty v0.2.0/go.mod h1:ipq/a2n7PKx3OHsz4KJII5eveXtPO4qwEXGdVfWzfnI=


### PR DESCRIPTION
Adding the maven global settings so that the provider config can be set correctly to use this global setting and select the correct local repository.