### PR TITLE
:sparkles: inject setting resources.

### DIFF
--- a/cmd/injector.go
+++ b/cmd/injector.go
@@ -147,6 +147,16 @@ func (r *ResourceInjector) build(md *Metadata) (err error) {
 					return
 				}
 			}
+		case "setting":
+			setting := &api.Setting{}
+			err = addon.Setting.Get(parsed.value, &setting.Value)
+			if err != nil {
+				return
+			}
+			err = r.add(&resource, setting)
+			if err != nil {
+				return
+			}
 		default:
 			err = &SelectorNotSupported{Selector: resource.Selector}
 			return


### PR DESCRIPTION
Support injecting _general_ settings (Resources) into extension configuration.
Example:
```
  metadata:
    provider:
      address: localhost:$(PORT)
      initConfig:
      - providerSpecificConfig:
          mavenInsecure: $(maven.insecure)
          mavenSettingsFile: $(maven.settings.path)
      name: java
    resources:
    - fields:
      - key: maven.settings.path
        name: settings
        path: /shared/creds/maven/settings.xml
      selector: identity:kind=maven
    - fields:
      - key: maven.insecure
        name: value
      selector: setting:key=mvn.insecure.enabled

```