### PR TITLE
:sparkles: Inject typed values.

### DIFF
--- a/cmd/injector.go
+++ b/cmd/injector.go
@@ -253,15 +253,16 @@ func (r *ResourceInjector) inject(in any) (out any) {
 				break
 			}
 			v := r.dict[match[2]]
-			if len(node) == len(match[0]) {
+			if len(node) > len(match[0]) {
+				node = strings.Replace(
+					node,
+					match[0],
+					r.string(v),
+					-1)
+			} else {
 				out = v
 				return
 			}
-			node = strings.Replace(
-				node,
-				match[0],
-				r.string(v),
-				-1)
 		}
 		out = node
 	default:

--- a/cmd/injector.go
+++ b/cmd/injector.go
@@ -15,6 +15,7 @@ import (
 	"github.com/konveyor/tackle2-hub/nas"
 )
 
+// KeyRegex $(variable)
 var (
 	KeyRegex = regexp.MustCompile(`(\$\()([^)]+)(\))`)
 )

--- a/cmd/injector.go
+++ b/cmd/injector.go
@@ -116,7 +116,7 @@ func (f *Field) cast(object any) (cast any, err error) {
 		case string:
 			cast, err = strconv.Atoi(x)
 		default:
-			err = errors.New("expected: int|boolean|string")
+			err = errors.New("expected: integer|boolean|string")
 		}
 	case "boolean":
 		switch x := object.(type) {
@@ -131,10 +131,10 @@ func (f *Field) cast(object any) (cast any, err error) {
 		case string:
 			cast, err = strconv.ParseBool(x)
 		default:
-			err = errors.New("expected: int|boolean|string")
+			err = errors.New("expected: integer|boolean|string")
 		}
 	default:
-		err = errors.New("expected: integer|boolean")
+		err = errors.New("expected: integer|boolean|string")
 	}
 	return
 }


### PR DESCRIPTION
Inject variables using true or _cast_ types when variable references not embedded in other text.

Consider:
```
metadata:
 provider:
   address: localhost:$(PORT)
   initConfig:
   - providerSpecificConfig:
       mavenInsecure: $(maven.insecure)
       mavenSettingsFile: $(maven.settings.path)
   name: java 
 resources:
 - selector: identity:kind=maven
   fields:
   - key: maven.settings.path
     name: settings
     path: /shared/creds/maven/settings.xml
 - selector: setting:key=mvn.insecure.enabled
   fields:
   - key: maven.insecure
     name: value
```

For example:
```
mavenInsecure = $(maven.insecure)
```
$(maven.insecure) has a _true_ type of boolean (as stored in the db) so it will be injected as:
```yaml
mavenInsecure: true
```
For cases when the _true_ type is different,  an optional `type` field may be used to cast.  In the previous example, if maven.insecure was stored as a string "true" but need to be injected as a boolean, the type field may be used.
```
 - selector: setting:key=mvn.insecure.enabled
   fields:
   - key: maven.insecure
     name: value
     type: boolean
```

While we're at it, (and to help with testing), support for _default_ values added.
```
 - selector: setting:key=mvn.insecure.enabled
   fields:
   - key: maven.insecure
     name: value
     type: boolean
     default: false
```