### PR TITLE
:sparkles: Inject location

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -18,7 +18,7 @@ jobs:
           docker save -o /tmp/tackle2-addon-analyzer.tar quay.io/konveyor/tackle2-addon-analyzer:latest
 
       - name: Upload tackle2-addon-analyzer image as artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: tackle2-addon-analyzer
           path: /tmp/tackle2-addon-analyzer.tar

--- a/Makefile
+++ b/Makefile
@@ -31,6 +31,9 @@ fmt: $(GOIMPORTS)
 vet:
 	go vet $(PKG)
 
+test:
+	go test -count=1 -v ./cmd/...
+
 # Ensure goimports installed.
 $(GOIMPORTS):
 	go install golang.org/x/tools/cmd/goimports@v0.24

--- a/cmd/analyzer.go
+++ b/cmd/analyzer.go
@@ -52,8 +52,11 @@ func (r *Analyzer) Run() (issueBuilder *builder.Issues, depBuilder *builder.Deps
 
 // options builds Analyzer options.
 func (r *Analyzer) options(output, depOutput string) (options command.Options, err error) {
+	variables := map[string]any{
+		"location": r.Mode.Location(),
+	}
 	settings := &Settings{}
-	err = settings.AppendExtensions()
+	err = settings.AppendExtensions(variables)
 	if err != nil {
 		return
 	}

--- a/cmd/analyzer.go
+++ b/cmd/analyzer.go
@@ -52,11 +52,8 @@ func (r *Analyzer) Run() (issueBuilder *builder.Issues, depBuilder *builder.Deps
 
 // options builds Analyzer options.
 func (r *Analyzer) options(output, depOutput string) (options command.Options, err error) {
-	variables := map[string]any{
-		"location": r.Mode.Location(),
-	}
 	settings := &Settings{}
-	err = settings.AppendExtensions(variables)
+	err = settings.AppendExtensions(&r.Mode)
 	if err != nil {
 		return
 	}

--- a/cmd/injector.go
+++ b/cmd/injector.go
@@ -73,21 +73,21 @@ func (e *TypeError) Is(err error) (matched bool) {
 	return
 }
 
-// KeyRedefinedError reports key redefined errors.
-type KeyRedefinedError struct {
+// KeyConflictError reports key redefined errors.
+type KeyConflictError struct {
 	Key   string
 	Value any
 }
 
-func (e *KeyRedefinedError) Error() (s string) {
+func (e *KeyConflictError) Error() (s string) {
 	return fmt.Sprintf(
 		"Key: '%s' = '%v' cannot be redefined.",
 		e.Key,
 		e.Value)
 }
 
-func (e *KeyRedefinedError) Is(err error) (matched bool) {
-	var inst *KeyRedefinedError
+func (e *KeyConflictError) Is(err error) (matched bool) {
+	var inst *KeyConflictError
 	matched = errors.As(err, &inst)
 	return
 }
@@ -425,7 +425,7 @@ func (r *ResourceInjector) addField(f *Field, v any) (err error) {
 		}
 	}
 	if _, found := r.dict[f.Key]; found {
-		err = &KeyRedefinedError{
+		err = &KeyConflictError{
 			Key:   f.Key,
 			Value: v,
 		}

--- a/cmd/injector.go
+++ b/cmd/injector.go
@@ -73,6 +73,25 @@ func (e *TypeError) Is(err error) (matched bool) {
 	return
 }
 
+// KeyRedefinedError reports key redefined errors.
+type KeyRedefinedError struct {
+	Key   string
+	Value any
+}
+
+func (e *KeyRedefinedError) Error() (s string) {
+	return fmt.Sprintf(
+		"Key: '%s' = '%v' cannot be redefined.",
+		e.Key,
+		e.Value)
+}
+
+func (e *KeyRedefinedError) Is(err error) (matched bool) {
+	var inst *KeyRedefinedError
+	matched = errors.As(err, &inst)
+	return
+}
+
 // Field injection specification.
 type Field struct {
 	Name    string `json:"name"`
@@ -179,56 +198,141 @@ func (p *ParsedSelector) With(s string) {
 	}
 }
 
-// ResourceInjector inject resources into extension metadata.
-// Example:
-//   metadata:
-//    provider:
-//      address: localhost:$(PORT)
-//      initConfig:
-//      - providerSpecificConfig:
-//          mavenInsecure: $(maven.insecure)
-//          mavenSettingsFile: $(maven.settings.path)
-//      name: java
-//    resources:
-//    - selector: identity:kind=maven
-//      fields:
-//      - key: maven.settings.path
-//        name: settings
-//        path: /shared/creds/maven/settings.xml
-//    - selector: setting:key=mvn.insecure.enabled
-//      fields:
-//      - key: maven.insecure
-//        name: value
-type ResourceInjector struct {
+// Injector replaces variables in the object.
+// format: $(variable).
+type Injector struct {
 	dict map[string]any
 }
 
 // Inject resources into extension metadata.
-// Returns injected provider (settings).
-func (r *ResourceInjector) Inject(extension *api.Extension) (p *provider.Config, err error) {
-	mp := r.asMap(extension.Metadata)
-	md := Metadata{}
-	err = r.object(mp, &md)
-	if err != nil {
-		return
-	}
-	err = r.build(&md)
-	if err != nil {
-		return
-	}
-	mp = r.asMap(&md.Provider)
+func (r *Injector) Inject(md *Metadata) (err error) {
+	r.init()
+	mp := r.asMap(md)
 	mp = r.inject(mp).(map[string]any)
-	err = r.object(mp, &md.Provider)
+	err = r.object(mp, md)
 	if err != nil {
 		return
 	}
-	p = &md.Provider
+	return
+}
+
+// Use map.
+func (r *Injector) Use(d map[string]any) {
+	r.dict = d
+}
+
+// constructor.
+func (r *Injector) init() {
+	if r.dict == nil {
+		r.dict = make(map[string]any)
+	}
+}
+
+// inject replaces `dict` variables referenced in metadata.
+func (r *Injector) inject(in any) (out any) {
+	if r.dict == nil {
+		return
+	}
+	switch node := in.(type) {
+	case map[string]any:
+		for k, v := range node {
+			node[k] = r.inject(v)
+		}
+		out = node
+	case []any:
+		var injected []any
+		for _, n := range node {
+			injected = append(
+				injected,
+				r.inject(n))
+		}
+		out = injected
+	case string:
+		for {
+			match := KeyRegex.FindStringSubmatch(node)
+			if len(match) < 3 {
+				break
+			}
+			v := r.dict[match[2]]
+			if len(node) > len(match[0]) {
+				node = strings.Replace(
+					node,
+					match[0],
+					r.string(v),
+					-1)
+			} else {
+				out = v
+				return
+			}
+		}
+		out = node
+	default:
+		out = node
+	}
+	return
+}
+
+// objectMap returns a map for a resource object.
+func (r *Injector) asMap(object any) (mp map[string]any) {
+	b, _ := json.Marshal(object)
+	mp = make(map[string]any)
+	_ = json.Unmarshal(b, &mp)
+	return
+}
+
+// objectMap returns a map for a resource object.
+func (r *Injector) object(mp map[string]any, object any) (err error) {
+	b, _ := json.Marshal(mp)
+	err = json.Unmarshal(b, object)
+	return
+}
+
+// string returns a string representation of a field value.
+func (r *Injector) string(object any) (s string) {
+	if object != nil {
+		s = fmt.Sprintf("%v", object)
+	}
+	return
+}
+
+// ResourceInjector inject resources into extension metadata.
+// Example:
+//
+//	metadata:
+//	 provider:
+//	   address: localhost:$(PORT)
+//	   initConfig:
+//	   - providerSpecificConfig:
+//	       mavenInsecure: $(maven.insecure)
+//	       mavenSettingsFile: $(maven.settings.path)
+//	   name: java
+//	 resources:
+//	 - selector: identity:kind=maven
+//	   fields:
+//	   - key: maven.settings.path
+//	     name: settings
+//	     path: /shared/creds/maven/settings.xml
+//	 - selector: setting:key=mvn.insecure.enabled
+//	   fields:
+//	   - key: maven.insecure
+//	     name: value
+type ResourceInjector struct {
+	Injector
+}
+
+// Inject resources into extension metadata.
+func (r *ResourceInjector) Inject(md *Metadata) (err error) {
+	r.init()
+	err = r.build(md)
+	if err != nil {
+		return
+	}
+	err = r.Injector.Inject(md)
 	return
 }
 
 // build builds resource dictionary.
 func (r *ResourceInjector) build(md *Metadata) (err error) {
-	r.dict = make(map[string]any)
 	application, err := addon.Task.Application()
 	if err != nil {
 		return
@@ -320,6 +424,13 @@ func (r *ResourceInjector) addField(f *Field, v any) (err error) {
 			return
 		}
 	}
+	if _, found := r.dict[f.Key]; found {
+		err = &KeyRedefinedError{
+			Key:   f.Key,
+			Value: v,
+		}
+		return
+	}
 	r.dict[f.Key] = v
 	return
 }
@@ -339,69 +450,5 @@ func (r *ResourceInjector) write(path string, object any) (err error) {
 	}()
 	s := r.string(object)
 	_, err = f.Write([]byte(s))
-	return
-}
-
-// string returns a string representation of a field value.
-func (r *ResourceInjector) string(object any) (s string) {
-	if object != nil {
-		s = fmt.Sprintf("%v", object)
-	}
-	return
-}
-
-// objectMap returns a map for a resource object.
-func (r *ResourceInjector) asMap(object any) (mp map[string]any) {
-	b, _ := json.Marshal(object)
-	mp = make(map[string]any)
-	_ = json.Unmarshal(b, &mp)
-	return
-}
-
-// objectMap returns a map for a resource object.
-func (r *ResourceInjector) object(mp map[string]any, object any) (err error) {
-	b, _ := json.Marshal(mp)
-	err = json.Unmarshal(b, object)
-	return
-}
-
-// inject replaces `dict` variables referenced in metadata.
-func (r *ResourceInjector) inject(in any) (out any) {
-	switch node := in.(type) {
-	case map[string]any:
-		for k, v := range node {
-			node[k] = r.inject(v)
-		}
-		out = node
-	case []any:
-		var injected []any
-		for _, n := range node {
-			injected = append(
-				injected,
-				r.inject(n))
-		}
-		out = injected
-	case string:
-		for {
-			match := KeyRegex.FindStringSubmatch(node)
-			if len(match) < 3 {
-				break
-			}
-			v := r.dict[match[2]]
-			if len(node) > len(match[0]) {
-				node = strings.Replace(
-					node,
-					match[0],
-					r.string(v),
-					-1)
-			} else {
-				out = v
-				return
-			}
-		}
-		out = node
-	default:
-		out = node
-	}
 	return
 }

--- a/cmd/mode.go
+++ b/cmd/mode.go
@@ -49,10 +49,15 @@ func (r *Mode) AddOptions(options *command.Options, settings *Settings) (err err
 		settings.Mode(provider.SourceOnlyAnalysisMode)
 		options.Add("--no-dependency-rules")
 	}
+	return
+}
+
+// Location returns the location to be analyzed.
+func (r *Mode) Location() (path string) {
 	if r.Binary {
-		settings.Location(r.path.binary)
+		path = r.path.binary
 	} else {
-		settings.Location(r.path.appDir)
+		path = r.path.appDir
 	}
 	return
 }

--- a/cmd/settings.go
+++ b/cmd/settings.go
@@ -17,7 +17,7 @@ import (
 const (
 	// Builtin namespace.
 	Builtin = "builtin"
-	// BuiltinLocation The Location passed to the provider.
+	// BuiltinLocation The (code) Location passed to the provider.
 	BuiltinLocation = Builtin + ".location"
 )
 

--- a/cmd/settings.go
+++ b/cmd/settings.go
@@ -14,6 +14,13 @@ import (
 	"gopkg.in/yaml.v2"
 )
 
+const (
+	// Builtin namespace.
+	Builtin = "builtin"
+	// BuiltinLocation The Location passed to the provider.
+	BuiltinLocation = Builtin + ".location"
+)
+
 // Settings - provider settings file.
 type Settings struct {
 	index   int
@@ -39,7 +46,7 @@ func (r *Settings) Read() (err error) {
 }
 
 // AppendExtensions adds extension fragments.
-func (r *Settings) AppendExtensions(variables map[string]any) (err error) {
+func (r *Settings) AppendExtensions(mode *Mode) (err error) {
 	addon, err := addon.Addon(true)
 	if err != nil {
 		return
@@ -47,15 +54,17 @@ func (r *Settings) AppendExtensions(variables map[string]any) (err error) {
 	for _, extension := range addon.Extensions {
 		var md *Metadata
 		md, err = r.metadata(&extension)
+		if r.hasProvider(&md.Provider) {
+			continue
+		}
+		builtin := r.injectBuiltins(md, mode)
 		injector := ResourceInjector{}
-		injector.Use(variables)
+		injector.Use(builtin)
 		err = injector.Inject(md)
 		if err != nil {
 			return
 		}
-		if !r.hasProvider(md.Provider.Name) {
-			r.content = append(r.content, md.Provider)
-		}
+		r.content = append(r.content, md.Provider)
 	}
 	return
 }
@@ -128,6 +137,18 @@ func (r *Settings) ProxySettings() (err error) {
 	return
 }
 
+// injectBuiltins injects `builtin` field values.
+func (r *Settings) injectBuiltins(md *Metadata, mode *Mode) (builtin map[string]any) {
+	builtin = make(map[string]any)
+	list := md.Provider.InitConfig
+	for i := range list {
+		in := &list[i]
+		in.Location = mode.Location()
+		builtin[BuiltinLocation] = in.Location
+	}
+	return
+}
+
 // getProxy set proxy settings.
 func (r *Settings) getProxy(kind string) (url string, excluded []string, err error) {
 	var p *api.Proxy
@@ -170,9 +191,9 @@ func (r *Settings) path() (p string) {
 }
 
 // hasProvider returns true when the provider found.
-func (r *Settings) hasProvider(name string) (found bool) {
-	for _, p := range r.content {
-		if p.Name == name {
+func (r *Settings) hasProvider(p *provider.Config) (found bool) {
+	for i := range r.content {
+		if r.content[i].Name == p.Name {
 			found = true
 			break
 		}


### PR DESCRIPTION
Add support for injecting the source code path (to be analyzed) in the extension metadata.  The `Location` field will continue to be injected.  There are providers that do not honor the Location field but instead expect a `workspaceFolders` array populated.  This is an inconsistency in providers.  To support this, the location needs to be templated. A new `location` variable in the `builtin` namespace may be used by the extension writer.
Example:
```
metadata:
  provider:
    address: localhost:$(PORT)
    initConfig:
    - providerSpecificConfig:
        lspServerName: generic
        lspServerPath: /usr/local/bin/pylsp
        workspaceFolders:
        - $(builtin.location)                  <-------------- HERE
        dependencyFolders:
        - examples/python/__pycache__
        - examples/python/.venv
    name: python
```