### PR TITLE
:bug: Fix analyzer error relay to task. (#144)

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -18,7 +18,7 @@ jobs:
           docker save -o /tmp/tackle2-addon-analyzer.tar quay.io/konveyor/tackle2-addon-analyzer:latest
 
       - name: Upload tackle2-addon-analyzer image as artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: tackle2-addon-analyzer
           path: /tmp/tackle2-addon-analyzer.tar

--- a/hack/examples/deps.yaml
+++ b/hack/examples/deps.yaml
@@ -1,0 +1,1163 @@
+- fileURI: file:///shared/source/tackle-testapp/pom.xml
+  provider: java
+  dependencies:
+  - name: antlr.antlr
+    version: 2.7.7
+    type: compile
+    indirect: true
+    resolvedIdentifier: 52f15b99911ab8b8bc8744675f5cf1994a626fb8
+    extras:
+      artifactId: antlr
+      baseDep:
+        extras:
+          artifactId: hibernate-entitymanager
+          groupId: org.hibernate
+          pomPath: /shared/source/tackle-testapp/pom.xml
+        name: org.hibernate.hibernate-entitymanager
+        version: 5.4.32.Final
+      groupId: antlr
+      pomPath: /shared/source/tackle-testapp/pom.xml
+    labels:
+    - konveyor.io/dep-source=open-source
+    - konveyor.io/language=java
+    prefix: file:///cache/m2/antlr/antlr/2.7.7
+  - name: ch.qos.logback.logback-classic
+    version: 1.1.7
+    type: compile
+    resolvedIdentifier: 044c01db0f7d7aac366fb952a89c10251ed86f44
+    extras:
+      artifactId: logback-classic
+      groupId: ch.qos.logback
+      pomPath: /shared/source/tackle-testapp/pom.xml
+    labels:
+    - konveyor.io/dep-source=open-source
+    - konveyor.io/language=java
+    prefix: file:///cache/m2/ch/qos/logback/logback-classic/1.1.7
+  - name: ch.qos.logback.logback-core
+    version: 1.1.7
+    type: compile
+    indirect: true
+    resolvedIdentifier: 6d1bdb1e28c56a8f989366b339f0f62545696e6d
+    extras:
+      artifactId: logback-core
+      baseDep:
+        extras:
+          artifactId: logback-classic
+          groupId: ch.qos.logback
+          pomPath: /shared/source/tackle-testapp/pom.xml
+        name: ch.qos.logback.logback-classic
+        version: 1.1.7
+      groupId: ch.qos.logback
+      pomPath: /shared/source/tackle-testapp/pom.xml
+    labels:
+    - konveyor.io/dep-source=open-source
+    - konveyor.io/language=java
+    prefix: file:///cache/m2/ch/qos/logback/logback-core/1.1.7
+  - name: com.fasterxml.classmate
+    version: 1.5.1
+    type: compile
+    indirect: true
+    resolvedIdentifier: d5d564526c142037daead331ee5278c088777858
+    extras:
+      artifactId: classmate
+      baseDep:
+        extras:
+          artifactId: hibernate-validator
+          groupId: org.hibernate.validator
+          pomPath: /shared/source/tackle-testapp/pom.xml
+        name: org.hibernate.validator.hibernate-validator
+        version: 6.2.0.Final
+      groupId: com.fasterxml
+      pomPath: /shared/source/tackle-testapp/pom.xml
+    labels:
+    - konveyor.io/dep-source=open-source
+    - konveyor.io/language=java
+    prefix: file:///cache/m2/com/fasterxml/classmate/1.5.1
+  - name: com.fasterxml.jackson.core.jackson-annotations
+    version: 2.12.3
+    type: compile
+    indirect: true
+    resolvedIdentifier: 87859f29ceebfab7a873c3b4f4b89c9a594b2842
+    extras:
+      artifactId: jackson-annotations
+      baseDep:
+        extras:
+          artifactId: jackson-databind
+          groupId: com.fasterxml.jackson.core
+          pomPath: /shared/source/tackle-testapp/pom.xml
+        name: com.fasterxml.jackson.core.jackson-databind
+        version: 2.12.3
+      groupId: com.fasterxml.jackson.core
+      pomPath: /shared/source/tackle-testapp/pom.xml
+    labels:
+    - konveyor.io/dep-source=open-source
+    - konveyor.io/language=java
+    prefix: file:///cache/m2/com/fasterxml/jackson/core/jackson-annotations/2.12.3
+  - name: com.fasterxml.jackson.core.jackson-core
+    version: 2.12.3
+    type: compile
+    resolvedIdentifier: ef6abf067337134089d074f411306a51f11a4d62
+    extras:
+      artifactId: jackson-core
+      groupId: com.fasterxml.jackson.core
+      pomPath: /shared/source/tackle-testapp/pom.xml
+    labels:
+    - konveyor.io/dep-source=open-source
+    - konveyor.io/language=java
+    prefix: file:///cache/m2/com/fasterxml/jackson/core/jackson-core/2.12.3
+  - name: com.fasterxml.jackson.core.jackson-databind
+    version: 2.12.3
+    type: compile
+    resolvedIdentifier: 2b186d9cc73cfb9272171357d17f0979eac44889
+    extras:
+      artifactId: jackson-databind
+      groupId: com.fasterxml.jackson.core
+      pomPath: /shared/source/tackle-testapp/pom.xml
+    labels:
+    - konveyor.io/dep-source=open-source
+    - konveyor.io/language=java
+    prefix: file:///cache/m2/com/fasterxml/jackson/core/jackson-databind/2.12.3
+  - name: com.fasterxml.jackson.datatype.jackson-datatype-jsr310
+    version: 2.12.3
+    type: runtime
+    indirect: true
+    resolvedIdentifier: db7822a553c167e95bdda25d0d6db44bd3abf847
+    extras:
+      artifactId: jackson-datatype-jsr310
+      baseDep:
+        extras:
+          artifactId: spring-boot-starter-actuator
+          groupId: org.springframework.boot
+          pomPath: /shared/source/tackle-testapp/pom.xml
+        name: org.springframework.boot.spring-boot-starter-actuator
+        version: 2.5.0
+      groupId: com.fasterxml.jackson.datatype
+      pomPath: /shared/source/tackle-testapp/pom.xml
+    labels:
+    - konveyor.io/dep-source=open-source
+    - konveyor.io/language=java
+    prefix: file:///cache/m2/com/fasterxml/jackson/datatype/jackson-datatype-jsr310/2.12.3
+  - name: com.oracle.database.jdbc.ojdbc11
+    version: 21.1.0.0
+    type: compile
+    resolvedIdentifier: b158fd98e1158f9d41c51b5442dda336816bc1f6
+    extras:
+      artifactId: ojdbc11
+      groupId: com.oracle.database.jdbc
+      pomPath: /shared/source/tackle-testapp/pom.xml
+    labels:
+    - konveyor.io/dep-source=open-source
+    - konveyor.io/language=java
+    prefix: file:///cache/m2/com/oracle/database/jdbc/ojdbc11/21.1.0.0
+  - name: com.sun.istack.istack-commons-runtime
+    version: 3.0.7
+    type: compile
+    indirect: true
+    resolvedIdentifier: 8eb4c6b0e9b0a1fadf53fce8b3fc8415b00469ef
+    extras:
+      artifactId: istack-commons-runtime
+      baseDep:
+        extras:
+          artifactId: hibernate-entitymanager
+          groupId: org.hibernate
+          pomPath: /shared/source/tackle-testapp/pom.xml
+        name: org.hibernate.hibernate-entitymanager
+        version: 5.4.32.Final
+      groupId: com.sun.istack
+      pomPath: /shared/source/tackle-testapp/pom.xml
+    labels:
+    - konveyor.io/dep-source=open-source
+    - konveyor.io/language=java
+    prefix: file:///cache/m2/com/sun/istack/istack-commons-runtime/3.0.7
+  - name: com.sun.xml.fastinfoset.FastInfoset
+    version: 1.2.15
+    type: compile
+    indirect: true
+    resolvedIdentifier: 945cf1f4467c72add88309fb05cdf5e340b569f9
+    extras:
+      artifactId: FastInfoset
+      baseDep:
+        extras:
+          artifactId: hibernate-entitymanager
+          groupId: org.hibernate
+          pomPath: /shared/source/tackle-testapp/pom.xml
+        name: org.hibernate.hibernate-entitymanager
+        version: 5.4.32.Final
+      groupId: com.sun.xml.fastinfoset
+      pomPath: /shared/source/tackle-testapp/pom.xml
+    labels:
+    - konveyor.io/dep-source=open-source
+    - konveyor.io/language=java
+    prefix: file:///cache/m2/com/sun/xml/fastinfoset/FastInfoset/1.2.15
+  - name: io.konveyor.demo.config-utils
+    version: 1.0.0
+    type: compile
+    resolvedIdentifier: eac57bd08442422b69306d9a1fd018ef83ef6a37
+    extras:
+      artifactId: config-utils
+      groupId: io.konveyor.demo
+      pomPath: /shared/source/tackle-testapp/pom.xml
+    labels:
+    - konveyor.io/dep-source=internal
+    - konveyor.io/language=java
+    prefix: file:///cache/m2/io/konveyor/demo/config-utils/1.0.0
+  - name: io.micrometer.micrometer-core
+    version: 1.7.0
+    type: compile
+    indirect: true
+    resolvedIdentifier: fd50ef746ed294d4e064c0cd3a14ca08543d139c
+    extras:
+      artifactId: micrometer-core
+      baseDep:
+        extras:
+          artifactId: spring-boot-starter-actuator
+          groupId: org.springframework.boot
+          pomPath: /shared/source/tackle-testapp/pom.xml
+        name: org.springframework.boot.spring-boot-starter-actuator
+        version: 2.5.0
+      groupId: io.micrometer
+      pomPath: /shared/source/tackle-testapp/pom.xml
+    labels:
+    - konveyor.io/dep-source=open-source
+    - konveyor.io/language=java
+    prefix: file:///cache/m2/io/micrometer/micrometer-core/1.7.0
+  - name: jakarta.annotation.jakarta.annotation-api
+    version: 1.3.5
+    type: compile
+    indirect: true
+    resolvedIdentifier: beb7649988a22ea30a17fcaeba8584323e86df74
+    extras:
+      artifactId: jakarta.annotation-api
+      baseDep:
+        extras:
+          artifactId: spring-boot-starter-actuator
+          groupId: org.springframework.boot
+          pomPath: /shared/source/tackle-testapp/pom.xml
+        name: org.springframework.boot.spring-boot-starter-actuator
+        version: 2.5.0
+      groupId: jakarta.annotation
+      pomPath: /shared/source/tackle-testapp/pom.xml
+    labels:
+    - konveyor.io/dep-source=open-source
+    - konveyor.io/language=java
+    prefix: file:///cache/m2/jakarta/annotation/jakarta.annotation-api/1.3.5
+  - name: jakarta.validation.jakarta.validation-api
+    version: 2.0.2
+    type: compile
+    indirect: true
+    resolvedIdentifier: fc029778f5494ed05e5833f8bdb57e36dbda38aa
+    extras:
+      artifactId: jakarta.validation-api
+      baseDep:
+        extras:
+          artifactId: hibernate-validator
+          groupId: org.hibernate.validator
+          pomPath: /shared/source/tackle-testapp/pom.xml
+        name: org.hibernate.validator.hibernate-validator
+        version: 6.2.0.Final
+      groupId: jakarta.validation
+      pomPath: /shared/source/tackle-testapp/pom.xml
+    labels:
+    - konveyor.io/dep-source=open-source
+    - konveyor.io/language=java
+    prefix: file:///cache/m2/jakarta/validation/jakarta.validation-api/2.0.2
+  - name: javax.activation.javax.activation-api
+    version: 1.2.0
+    type: compile
+    indirect: true
+    resolvedIdentifier: 1aa9ef58e50ba6868b2e955d61fcd73be5b4cea5
+    extras:
+      artifactId: javax.activation-api
+      baseDep:
+        extras:
+          artifactId: hibernate-entitymanager
+          groupId: org.hibernate
+          pomPath: /shared/source/tackle-testapp/pom.xml
+        name: org.hibernate.hibernate-entitymanager
+        version: 5.4.32.Final
+      groupId: javax.activation
+      pomPath: /shared/source/tackle-testapp/pom.xml
+    labels:
+    - konveyor.io/dep-source=open-source
+    - konveyor.io/language=java
+    prefix: file:///cache/m2/javax/activation/javax.activation-api/1.2.0
+  - name: javax.persistence.javax.persistence-api
+    version: "2.2"
+    type: compile
+    indirect: true
+    resolvedIdentifier: ac7080de51fc0596317c15e12ed441f7c0a84d09
+    extras:
+      artifactId: javax.persistence-api
+      baseDep:
+        extras:
+          artifactId: hibernate-entitymanager
+          groupId: org.hibernate
+          pomPath: /shared/source/tackle-testapp/pom.xml
+        name: org.hibernate.hibernate-entitymanager
+        version: 5.4.32.Final
+      groupId: javax.persistence
+      pomPath: /shared/source/tackle-testapp/pom.xml
+    labels:
+    - konveyor.io/dep-source=open-source
+    - konveyor.io/language=java
+    prefix: file:///cache/m2/javax/persistence/javax.persistence-api/2.2
+  - name: javax.xml.bind.jaxb-api
+    version: 2.3.1
+    type: compile
+    indirect: true
+    resolvedIdentifier: c42c51ae84892b73ef7de5351188908e673f5c69
+    extras:
+      artifactId: jaxb-api
+      baseDep:
+        extras:
+          artifactId: hibernate-entitymanager
+          groupId: org.hibernate
+          pomPath: /shared/source/tackle-testapp/pom.xml
+        name: org.hibernate.hibernate-entitymanager
+        version: 5.4.32.Final
+      groupId: javax.xml.bind
+      pomPath: /shared/source/tackle-testapp/pom.xml
+    labels:
+    - konveyor.io/dep-source=open-source
+    - konveyor.io/language=java
+    prefix: file:///cache/m2/javax/xml/bind/jaxb-api/2.3.1
+  - name: net.bytebuddy.byte-buddy
+    version: 1.10.22
+    type: compile
+    indirect: true
+    resolvedIdentifier: 14de25cfee49cd27ae19153674bbb34c04c45d52
+    extras:
+      artifactId: byte-buddy
+      baseDep:
+        extras:
+          artifactId: hibernate-entitymanager
+          groupId: org.hibernate
+          pomPath: /shared/source/tackle-testapp/pom.xml
+        name: org.hibernate.hibernate-entitymanager
+        version: 5.4.32.Final
+      groupId: net.bytebuddy
+      pomPath: /shared/source/tackle-testapp/pom.xml
+    labels:
+    - konveyor.io/dep-source=open-source
+    - konveyor.io/language=java
+    prefix: file:///cache/m2/net/bytebuddy/byte-buddy/1.10.22
+  - name: org.apache.logging.log4j.log4j-api
+    version: 2.14.1
+    type: compile
+    indirect: true
+    resolvedIdentifier: 9199a73770616b1ca0b00f576db3231aaab4876a
+    extras:
+      artifactId: log4j-api
+      baseDep:
+        extras:
+          artifactId: spring-boot-starter-actuator
+          groupId: org.springframework.boot
+          pomPath: /shared/source/tackle-testapp/pom.xml
+        name: org.springframework.boot.spring-boot-starter-actuator
+        version: 2.5.0
+      groupId: org.apache.logging.log4j
+      pomPath: /shared/source/tackle-testapp/pom.xml
+    labels:
+    - konveyor.io/dep-source=open-source
+    - konveyor.io/language=java
+    prefix: file:///cache/m2/org/apache/logging/log4j/log4j-api/2.14.1
+  - name: org.apache.logging.log4j.log4j-to-slf4j
+    version: 2.14.1
+    type: compile
+    indirect: true
+    resolvedIdentifier: 4638502177d694ad6f429a122e32f84ceba7db41
+    extras:
+      artifactId: log4j-to-slf4j
+      baseDep:
+        extras:
+          artifactId: spring-boot-starter-actuator
+          groupId: org.springframework.boot
+          pomPath: /shared/source/tackle-testapp/pom.xml
+        name: org.springframework.boot.spring-boot-starter-actuator
+        version: 2.5.0
+      groupId: org.apache.logging.log4j
+      pomPath: /shared/source/tackle-testapp/pom.xml
+    labels:
+    - konveyor.io/dep-source=open-source
+    - konveyor.io/language=java
+    prefix: file:///cache/m2/org/apache/logging/log4j/log4j-to-slf4j/2.14.1
+  - name: org.apache.tomcat.tomcat-jdbc
+    version: 9.0.46
+    type: runtime
+    resolvedIdentifier: c3b975aba8359ecf35f6fca175c2e843a1d3c107
+    extras:
+      artifactId: tomcat-jdbc
+      groupId: org.apache.tomcat
+      pomPath: /shared/source/tackle-testapp/pom.xml
+    labels:
+    - konveyor.io/dep-source=open-source
+    - konveyor.io/language=java
+    prefix: file:///cache/m2/org/apache/tomcat/tomcat-jdbc/9.0.46
+  - name: org.apache.tomcat.tomcat-juli
+    version: 9.0.46
+    type: runtime
+    indirect: true
+    resolvedIdentifier: 1596051131c8426ebf744e0effed0e0005c87d57
+    extras:
+      artifactId: tomcat-juli
+      baseDep:
+        extras:
+          artifactId: tomcat-jdbc
+          groupId: org.apache.tomcat
+          pomPath: /shared/source/tackle-testapp/pom.xml
+        name: org.apache.tomcat.tomcat-jdbc
+        version: 9.0.46
+      groupId: org.apache.tomcat
+      pomPath: /shared/source/tackle-testapp/pom.xml
+    labels:
+    - konveyor.io/dep-source=open-source
+    - konveyor.io/language=java
+    prefix: file:///cache/m2/org/apache/tomcat/tomcat-juli/9.0.46
+  - name: org.apache.tomcat.tomcat-servlet-api
+    version: 9.0.46
+    type: provided
+    resolvedIdentifier: 1f5ec6292bbca9e6c35172044b5fee0b0a97ef24
+    extras:
+      artifactId: tomcat-servlet-api
+      groupId: org.apache.tomcat
+      pomPath: /shared/source/tackle-testapp/pom.xml
+    labels:
+    - konveyor.io/dep-source=open-source
+    - konveyor.io/language=java
+    prefix: file:///cache/m2/org/apache/tomcat/tomcat-servlet-api/9.0.46
+  - name: org.aspectj.aspectjrt
+    version: 1.9.6
+    type: compile
+    indirect: true
+    resolvedIdentifier: 2c4216b8c0f62edf69ec5cdd68619ba2aac5a4a1
+    extras:
+      artifactId: aspectjrt
+      baseDep:
+        extras:
+          artifactId: spring-data-jpa
+          groupId: org.springframework.data
+          pomPath: /shared/source/tackle-testapp/pom.xml
+        name: org.springframework.data.spring-data-jpa
+        version: 2.5.1
+      groupId: org.aspectj
+      pomPath: /shared/source/tackle-testapp/pom.xml
+    labels:
+    - konveyor.io/dep-source=open-source
+    - konveyor.io/language=java
+    prefix: file:///cache/m2/org/aspectj/aspectjrt/1.9.6
+  - name: org.checkerframework.checker-qual
+    version: 3.5.0
+    type: runtime
+    indirect: true
+    resolvedIdentifier: 408a4451ff5bdef60400a49657867db100ea0f83
+    extras:
+      artifactId: checker-qual
+      baseDep:
+        extras:
+          artifactId: postgresql
+          groupId: org.postgresql
+          pomPath: /shared/source/tackle-testapp/pom.xml
+        name: org.postgresql.postgresql
+        version: 42.2.23
+      groupId: org.checkerframework
+      pomPath: /shared/source/tackle-testapp/pom.xml
+    labels:
+    - konveyor.io/dep-source=open-source
+    - konveyor.io/language=java
+    prefix: file:///cache/m2/org/checkerframework/checker-qual/3.5.0
+  - name: org.dom4j.dom4j
+    version: 2.1.3
+    type: compile
+    indirect: true
+    resolvedIdentifier: 012854caa63db09d82bf973bc37d7226aaaef463
+    extras:
+      artifactId: dom4j
+      baseDep:
+        extras:
+          artifactId: hibernate-entitymanager
+          groupId: org.hibernate
+          pomPath: /shared/source/tackle-testapp/pom.xml
+        name: org.hibernate.hibernate-entitymanager
+        version: 5.4.32.Final
+      groupId: org.dom4j
+      pomPath: /shared/source/tackle-testapp/pom.xml
+    labels:
+    - konveyor.io/dep-source=open-source
+    - konveyor.io/language=java
+    prefix: file:///cache/m2/org/dom4j/dom4j/2.1.3
+  - name: org.glassfish.jaxb.jaxb-runtime
+    version: 2.3.1
+    type: compile
+    indirect: true
+    resolvedIdentifier: 1856da23a80b9b1374d925d6dcb4a21db2144204
+    extras:
+      artifactId: jaxb-runtime
+      baseDep:
+        extras:
+          artifactId: hibernate-entitymanager
+          groupId: org.hibernate
+          pomPath: /shared/source/tackle-testapp/pom.xml
+        name: org.hibernate.hibernate-entitymanager
+        version: 5.4.32.Final
+      groupId: org.glassfish.jaxb
+      pomPath: /shared/source/tackle-testapp/pom.xml
+    labels:
+    - konveyor.io/dep-source=open-source
+    - konveyor.io/language=java
+    prefix: file:///cache/m2/org/glassfish/jaxb/jaxb-runtime/2.3.1
+  - name: org.glassfish.jaxb.txw2
+    version: 2.3.1
+    type: compile
+    indirect: true
+    resolvedIdentifier: c78aa440484eab1a6e2104e4fe69d0945a3cb3da
+    extras:
+      artifactId: txw2
+      baseDep:
+        extras:
+          artifactId: hibernate-entitymanager
+          groupId: org.hibernate
+          pomPath: /shared/source/tackle-testapp/pom.xml
+        name: org.hibernate.hibernate-entitymanager
+        version: 5.4.32.Final
+      groupId: org.glassfish.jaxb
+      pomPath: /shared/source/tackle-testapp/pom.xml
+    labels:
+    - konveyor.io/dep-source=open-source
+    - konveyor.io/language=java
+    prefix: file:///cache/m2/org/glassfish/jaxb/txw2/2.3.1
+  - name: org.hdrhistogram.HdrHistogram
+    version: 2.1.12
+    type: compile
+    indirect: true
+    resolvedIdentifier: 9797702ee3e52e4be6bfbbc9fd20ac5447e7a541
+    extras:
+      artifactId: HdrHistogram
+      baseDep:
+        extras:
+          artifactId: spring-boot-starter-actuator
+          groupId: org.springframework.boot
+          pomPath: /shared/source/tackle-testapp/pom.xml
+        name: org.springframework.boot.spring-boot-starter-actuator
+        version: 2.5.0
+      groupId: org.hdrhistogram
+      pomPath: /shared/source/tackle-testapp/pom.xml
+    labels:
+    - konveyor.io/dep-source=open-source
+    - konveyor.io/language=java
+    prefix: file:///cache/m2/org/hdrhistogram/HdrHistogram/2.1.12
+  - name: org.hibernate.common.hibernate-commons-annotations
+    version: 5.1.2.Final
+    type: compile
+    indirect: true
+    resolvedIdentifier: 573f22ce360cd7a8bcc0dae4deecbe4e8861007d
+    extras:
+      artifactId: hibernate-commons-annotations
+      baseDep:
+        extras:
+          artifactId: hibernate-entitymanager
+          groupId: org.hibernate
+          pomPath: /shared/source/tackle-testapp/pom.xml
+        name: org.hibernate.hibernate-entitymanager
+        version: 5.4.32.Final
+      groupId: org.hibernate.common
+      pomPath: /shared/source/tackle-testapp/pom.xml
+    labels:
+    - konveyor.io/dep-source=open-source
+    - konveyor.io/language=java
+    prefix: file:///cache/m2/org/hibernate/common/hibernate-commons-annotations/5.1.2.Final
+  - name: org.hibernate.hibernate-core
+    version: 5.4.32.Final
+    type: compile
+    indirect: true
+    resolvedIdentifier: 5be381f7b6f3d4f17ce746e4ff54f4b8cdce40e4
+    extras:
+      artifactId: hibernate-core
+      baseDep:
+        extras:
+          artifactId: hibernate-entitymanager
+          groupId: org.hibernate
+          pomPath: /shared/source/tackle-testapp/pom.xml
+        name: org.hibernate.hibernate-entitymanager
+        version: 5.4.32.Final
+      groupId: org.hibernate
+      pomPath: /shared/source/tackle-testapp/pom.xml
+    labels:
+    - konveyor.io/dep-source=open-source
+    - konveyor.io/language=java
+    prefix: file:///cache/m2/org/hibernate/hibernate-core/5.4.32.Final
+  - name: org.hibernate.hibernate-entitymanager
+    version: 5.4.32.Final
+    type: compile
+    resolvedIdentifier: b315696800e16d33bfb297d66f87a792caa3facc
+    extras:
+      artifactId: hibernate-entitymanager
+      groupId: org.hibernate
+      pomPath: /shared/source/tackle-testapp/pom.xml
+    labels:
+    - konveyor.io/dep-source=open-source
+    - konveyor.io/language=java
+    prefix: file:///cache/m2/org/hibernate/hibernate-entitymanager/5.4.32.Final
+  - name: org.hibernate.validator.hibernate-validator
+    version: 6.2.0.Final
+    type: compile
+    resolvedIdentifier: 7f1beda5229a0c99a175603c18b3c66da44f966e
+    extras:
+      artifactId: hibernate-validator
+      groupId: org.hibernate.validator
+      pomPath: /shared/source/tackle-testapp/pom.xml
+    labels:
+    - konveyor.io/dep-source=open-source
+    - konveyor.io/language=java
+    prefix: file:///cache/m2/org/hibernate/validator/hibernate-validator/6.2.0.Final
+  - name: org.javassist.javassist
+    version: 3.27.0-GA
+    type: compile
+    indirect: true
+    resolvedIdentifier: 0b7565662bc91e9648aab437135f32beb040ac15
+    extras:
+      artifactId: javassist
+      baseDep:
+        extras:
+          artifactId: hibernate-entitymanager
+          groupId: org.hibernate
+          pomPath: /shared/source/tackle-testapp/pom.xml
+        name: org.hibernate.hibernate-entitymanager
+        version: 5.4.32.Final
+      groupId: org.javassist
+      pomPath: /shared/source/tackle-testapp/pom.xml
+    labels:
+    - konveyor.io/dep-source=open-source
+    - konveyor.io/language=java
+    prefix: file:///cache/m2/org/javassist/javassist/3.27.0-GA
+  - name: org.jboss.jandex
+    version: 2.2.3.Final
+    type: compile
+    indirect: true
+    resolvedIdentifier: c70053a1326428ec641be311ccf5551a8ec76a63
+    extras:
+      artifactId: jandex
+      baseDep:
+        extras:
+          artifactId: hibernate-entitymanager
+          groupId: org.hibernate
+          pomPath: /shared/source/tackle-testapp/pom.xml
+        name: org.hibernate.hibernate-entitymanager
+        version: 5.4.32.Final
+      groupId: org.jboss
+      pomPath: /shared/source/tackle-testapp/pom.xml
+    labels:
+    - konveyor.io/dep-source=open-source
+    - konveyor.io/language=java
+    prefix: file:///cache/m2/org/jboss/jandex/2.2.3.Final
+  - name: org.jboss.logging.jboss-logging
+    version: 3.4.1.Final
+    type: compile
+    indirect: true
+    resolvedIdentifier: 9d82f8eea1b5ed484775517d7588e320f9f7797a
+    extras:
+      artifactId: jboss-logging
+      baseDep:
+        extras:
+          artifactId: hibernate-entitymanager
+          groupId: org.hibernate
+          pomPath: /shared/source/tackle-testapp/pom.xml
+        name: org.hibernate.hibernate-entitymanager
+        version: 5.4.32.Final
+      groupId: org.jboss.logging
+      pomPath: /shared/source/tackle-testapp/pom.xml
+    labels:
+    - konveyor.io/dep-source=open-source
+    - konveyor.io/language=java
+    prefix: file:///cache/m2/org/jboss/logging/jboss-logging/3.4.1.Final
+  - name: org.jboss.spec.javax.transaction.jboss-transaction-api_1.2_spec
+    version: 1.1.1.Final
+    type: compile
+    indirect: true
+    resolvedIdentifier: 90823b310c573492696ad7e299b694ca2e70b4c1
+    extras:
+      artifactId: jboss-transaction-api_1.2_spec
+      baseDep:
+        extras:
+          artifactId: hibernate-entitymanager
+          groupId: org.hibernate
+          pomPath: /shared/source/tackle-testapp/pom.xml
+        name: org.hibernate.hibernate-entitymanager
+        version: 5.4.32.Final
+      groupId: org.jboss.spec.javax.transaction
+      pomPath: /shared/source/tackle-testapp/pom.xml
+    labels:
+    - konveyor.io/dep-source=open-source
+    - konveyor.io/language=java
+    prefix: file:///cache/m2/org/jboss/spec/javax/transaction/jboss-transaction-api_1.2_spec/1.1.1.Final
+  - name: org.jvnet.staxex.stax-ex
+    version: "1.8"
+    type: compile
+    indirect: true
+    resolvedIdentifier: cc7022b896125220e51f46fa50f4b68e564ffec1
+    extras:
+      artifactId: stax-ex
+      baseDep:
+        extras:
+          artifactId: hibernate-entitymanager
+          groupId: org.hibernate
+          pomPath: /shared/source/tackle-testapp/pom.xml
+        name: org.hibernate.hibernate-entitymanager
+        version: 5.4.32.Final
+      groupId: org.jvnet.staxex
+      pomPath: /shared/source/tackle-testapp/pom.xml
+    labels:
+    - konveyor.io/dep-source=open-source
+    - konveyor.io/language=java
+    prefix: file:///cache/m2/org/jvnet/staxex/stax-ex/1.8
+  - name: org.latencyutils.LatencyUtils
+    version: 2.0.3
+    type: runtime
+    indirect: true
+    resolvedIdentifier: 5baec26b6f9e5b17fdd200fc20af85eead4287c4
+    extras:
+      artifactId: LatencyUtils
+      baseDep:
+        extras:
+          artifactId: spring-boot-starter-actuator
+          groupId: org.springframework.boot
+          pomPath: /shared/source/tackle-testapp/pom.xml
+        name: org.springframework.boot.spring-boot-starter-actuator
+        version: 2.5.0
+      groupId: org.latencyutils
+      pomPath: /shared/source/tackle-testapp/pom.xml
+    labels:
+    - konveyor.io/dep-source=open-source
+    - konveyor.io/language=java
+    prefix: file:///cache/m2/org/latencyutils/LatencyUtils/2.0.3
+  - name: org.postgresql.postgresql
+    version: 42.2.23
+    type: compile
+    resolvedIdentifier: cc8565ec39dbfee32c2c87f125162fe8a3010c28
+    extras:
+      artifactId: postgresql
+      groupId: org.postgresql
+      pomPath: /shared/source/tackle-testapp/pom.xml
+    labels:
+    - konveyor.io/dep-source=open-source
+    - konveyor.io/language=java
+    prefix: file:///cache/m2/org/postgresql/postgresql/42.2.23
+  - name: org.slf4j.jul-to-slf4j
+    version: 1.7.30
+    type: compile
+    indirect: true
+    resolvedIdentifier: f09448bdaeee63bc0644abae571b2d17c83d16c1
+    extras:
+      artifactId: jul-to-slf4j
+      baseDep:
+        extras:
+          artifactId: spring-boot-starter-actuator
+          groupId: org.springframework.boot
+          pomPath: /shared/source/tackle-testapp/pom.xml
+        name: org.springframework.boot.spring-boot-starter-actuator
+        version: 2.5.0
+      groupId: org.slf4j
+      pomPath: /shared/source/tackle-testapp/pom.xml
+    labels:
+    - konveyor.io/dep-source=open-source
+    - konveyor.io/language=java
+    prefix: file:///cache/m2/org/slf4j/jul-to-slf4j/1.7.30
+  - name: org.slf4j.slf4j-api
+    version: 1.7.26
+    type: compile
+    indirect: true
+    resolvedIdentifier: 4d3419a58d77c07f49185aaa556a787d50508d27
+    extras:
+      artifactId: slf4j-api
+      baseDep:
+        extras:
+          artifactId: spring-data-jpa
+          groupId: org.springframework.data
+          pomPath: /shared/source/tackle-testapp/pom.xml
+        name: org.springframework.data.spring-data-jpa
+        version: 2.5.1
+      groupId: org.slf4j
+      pomPath: /shared/source/tackle-testapp/pom.xml
+    labels:
+    - konveyor.io/dep-source=open-source
+    - konveyor.io/language=java
+    prefix: file:///cache/m2/org/slf4j/slf4j-api/1.7.26
+  - name: org.springframework.boot.spring-boot
+    version: 2.5.0
+    type: compile
+    indirect: true
+    resolvedIdentifier: 48a6c425a45395e1ccfd99fd815c92d069040e43
+    extras:
+      artifactId: spring-boot
+      baseDep:
+        extras:
+          artifactId: spring-boot-starter-actuator
+          groupId: org.springframework.boot
+          pomPath: /shared/source/tackle-testapp/pom.xml
+        name: org.springframework.boot.spring-boot-starter-actuator
+        version: 2.5.0
+      groupId: org.springframework.boot
+      pomPath: /shared/source/tackle-testapp/pom.xml
+    labels:
+    - konveyor.io/dep-source=open-source
+    - konveyor.io/language=java
+    prefix: file:///cache/m2/org/springframework/boot/spring-boot/2.5.0
+  - name: org.springframework.boot.spring-boot-actuator
+    version: 2.5.0
+    type: compile
+    indirect: true
+    resolvedIdentifier: ee202daac01b6399b857d187cfdbf6d97d6adc8f
+    extras:
+      artifactId: spring-boot-actuator
+      baseDep:
+        extras:
+          artifactId: spring-boot-starter-actuator
+          groupId: org.springframework.boot
+          pomPath: /shared/source/tackle-testapp/pom.xml
+        name: org.springframework.boot.spring-boot-starter-actuator
+        version: 2.5.0
+      groupId: org.springframework.boot
+      pomPath: /shared/source/tackle-testapp/pom.xml
+    labels:
+    - konveyor.io/dep-source=open-source
+    - konveyor.io/language=java
+    prefix: file:///cache/m2/org/springframework/boot/spring-boot-actuator/2.5.0
+  - name: org.springframework.boot.spring-boot-actuator-autoconfigure
+    version: 2.5.0
+    type: compile
+    indirect: true
+    resolvedIdentifier: c527193b5cc67f7534c27860171e44187746aaf5
+    extras:
+      artifactId: spring-boot-actuator-autoconfigure
+      baseDep:
+        extras:
+          artifactId: spring-boot-starter-actuator
+          groupId: org.springframework.boot
+          pomPath: /shared/source/tackle-testapp/pom.xml
+        name: org.springframework.boot.spring-boot-starter-actuator
+        version: 2.5.0
+      groupId: org.springframework.boot
+      pomPath: /shared/source/tackle-testapp/pom.xml
+    labels:
+    - konveyor.io/dep-source=open-source
+    - konveyor.io/language=java
+    prefix: file:///cache/m2/org/springframework/boot/spring-boot-actuator-autoconfigure/2.5.0
+  - name: org.springframework.boot.spring-boot-autoconfigure
+    version: 2.5.0
+    type: compile
+    indirect: true
+    resolvedIdentifier: da542216009c858c2e8b32cb595578acc19d2df3
+    extras:
+      artifactId: spring-boot-autoconfigure
+      baseDep:
+        extras:
+          artifactId: spring-boot-starter-actuator
+          groupId: org.springframework.boot
+          pomPath: /shared/source/tackle-testapp/pom.xml
+        name: org.springframework.boot.spring-boot-starter-actuator
+        version: 2.5.0
+      groupId: org.springframework.boot
+      pomPath: /shared/source/tackle-testapp/pom.xml
+    labels:
+    - konveyor.io/dep-source=open-source
+    - konveyor.io/language=java
+    prefix: file:///cache/m2/org/springframework/boot/spring-boot-autoconfigure/2.5.0
+  - name: org.springframework.boot.spring-boot-starter
+    version: 2.5.0
+    type: compile
+    indirect: true
+    resolvedIdentifier: 391cbf83221ae09c1c0a471b25ab3221dfe46ef1
+    extras:
+      artifactId: spring-boot-starter
+      baseDep:
+        extras:
+          artifactId: spring-boot-starter-actuator
+          groupId: org.springframework.boot
+          pomPath: /shared/source/tackle-testapp/pom.xml
+        name: org.springframework.boot.spring-boot-starter-actuator
+        version: 2.5.0
+      groupId: org.springframework.boot
+      pomPath: /shared/source/tackle-testapp/pom.xml
+    labels:
+    - konveyor.io/dep-source=open-source
+    - konveyor.io/language=java
+    prefix: file:///cache/m2/org/springframework/boot/spring-boot-starter/2.5.0
+  - name: org.springframework.boot.spring-boot-starter-actuator
+    version: 2.5.0
+    type: compile
+    resolvedIdentifier: 76dd6dea415751e05491337b7ff22bd08ae70c7e
+    extras:
+      artifactId: spring-boot-starter-actuator
+      groupId: org.springframework.boot
+      pomPath: /shared/source/tackle-testapp/pom.xml
+    labels:
+    - konveyor.io/dep-source=open-source
+    - konveyor.io/language=java
+    prefix: file:///cache/m2/org/springframework/boot/spring-boot-starter-actuator/2.5.0
+  - name: org.springframework.boot.spring-boot-starter-logging
+    version: 2.5.0
+    type: compile
+    indirect: true
+    resolvedIdentifier: 60f06908ef3b39d8c8780898e749c4c846fabb84
+    extras:
+      artifactId: spring-boot-starter-logging
+      baseDep:
+        extras:
+          artifactId: spring-boot-starter-actuator
+          groupId: org.springframework.boot
+          pomPath: /shared/source/tackle-testapp/pom.xml
+        name: org.springframework.boot.spring-boot-starter-actuator
+        version: 2.5.0
+      groupId: org.springframework.boot
+      pomPath: /shared/source/tackle-testapp/pom.xml
+    labels:
+    - konveyor.io/dep-source=open-source
+    - konveyor.io/language=java
+    prefix: file:///cache/m2/org/springframework/boot/spring-boot-starter-logging/2.5.0
+  - name: org.springframework.data.spring-data-commons
+    version: 2.5.1
+    type: compile
+    indirect: true
+    resolvedIdentifier: bceeabb4ef399ba7ff8511f2931e1924a41cc921
+    extras:
+      artifactId: spring-data-commons
+      baseDep:
+        extras:
+          artifactId: spring-data-jpa
+          groupId: org.springframework.data
+          pomPath: /shared/source/tackle-testapp/pom.xml
+        name: org.springframework.data.spring-data-jpa
+        version: 2.5.1
+      groupId: org.springframework.data
+      pomPath: /shared/source/tackle-testapp/pom.xml
+    labels:
+    - konveyor.io/dep-source=open-source
+    - konveyor.io/language=java
+    prefix: file:///cache/m2/org/springframework/data/spring-data-commons/2.5.1
+  - name: org.springframework.data.spring-data-jpa
+    version: 2.5.1
+    type: compile
+    resolvedIdentifier: 461ebcc9fc00dca10a754b0e96583ce7d281d312
+    extras:
+      artifactId: spring-data-jpa
+      groupId: org.springframework.data
+      pomPath: /shared/source/tackle-testapp/pom.xml
+    labels:
+    - konveyor.io/dep-source=open-source
+    - konveyor.io/language=java
+    prefix: file:///cache/m2/org/springframework/data/spring-data-jpa/2.5.1
+  - name: org.springframework.spring-aop
+    version: 5.3.7
+    type: compile
+    indirect: true
+    resolvedIdentifier: 0bf1d9d12108b8ab2d9d71d5fd5fee02d3ee5bde
+    extras:
+      artifactId: spring-aop
+      baseDep:
+        extras:
+          artifactId: spring-data-jpa
+          groupId: org.springframework.data
+          pomPath: /shared/source/tackle-testapp/pom.xml
+        name: org.springframework.data.spring-data-jpa
+        version: 2.5.1
+      groupId: org.springframework
+      pomPath: /shared/source/tackle-testapp/pom.xml
+    labels:
+    - konveyor.io/dep-source=open-source
+    - konveyor.io/language=java
+    prefix: file:///cache/m2/org/springframework/spring-aop/5.3.7
+  - name: org.springframework.spring-beans
+    version: 5.3.7
+    type: compile
+    indirect: true
+    resolvedIdentifier: 654397f55cd4a4734f8b76282e98c88884d0367a
+    extras:
+      artifactId: spring-beans
+      baseDep:
+        extras:
+          artifactId: spring-data-jpa
+          groupId: org.springframework.data
+          pomPath: /shared/source/tackle-testapp/pom.xml
+        name: org.springframework.data.spring-data-jpa
+        version: 2.5.1
+      groupId: org.springframework
+      pomPath: /shared/source/tackle-testapp/pom.xml
+    labels:
+    - konveyor.io/dep-source=open-source
+    - konveyor.io/language=java
+    prefix: file:///cache/m2/org/springframework/spring-beans/5.3.7
+  - name: org.springframework.spring-context
+    version: 5.3.7
+    type: compile
+    indirect: true
+    resolvedIdentifier: 67e3176098c81702c76d20977deec8101b3faf8c
+    extras:
+      artifactId: spring-context
+      baseDep:
+        extras:
+          artifactId: spring-data-jpa
+          groupId: org.springframework.data
+          pomPath: /shared/source/tackle-testapp/pom.xml
+        name: org.springframework.data.spring-data-jpa
+        version: 2.5.1
+      groupId: org.springframework
+      pomPath: /shared/source/tackle-testapp/pom.xml
+    labels:
+    - konveyor.io/dep-source=open-source
+    - konveyor.io/language=java
+    prefix: file:///cache/m2/org/springframework/spring-context/5.3.7
+  - name: org.springframework.spring-core
+    version: 5.3.7
+    type: compile
+    indirect: true
+    resolvedIdentifier: 44ce199d05bb1ce9682621cd18953ea307485fc1
+    extras:
+      artifactId: spring-core
+      baseDep:
+        extras:
+          artifactId: spring-data-jpa
+          groupId: org.springframework.data
+          pomPath: /shared/source/tackle-testapp/pom.xml
+        name: org.springframework.data.spring-data-jpa
+        version: 2.5.1
+      groupId: org.springframework
+      pomPath: /shared/source/tackle-testapp/pom.xml
+    labels:
+    - konveyor.io/dep-source=open-source
+    - konveyor.io/language=java
+    prefix: file:///cache/m2/org/springframework/spring-core/5.3.7
+  - name: org.springframework.spring-expression
+    version: 5.3.7
+    type: compile
+    indirect: true
+    resolvedIdentifier: 30bd0b3e802e5ba4e4d9fc68e57cc0e755ba9f9f
+    extras:
+      artifactId: spring-expression
+      baseDep:
+        extras:
+          artifactId: spring-webmvc
+          groupId: org.springframework
+          pomPath: /shared/source/tackle-testapp/pom.xml
+        name: org.springframework.spring-webmvc
+        version: 5.3.7
+      groupId: org.springframework
+      pomPath: /shared/source/tackle-testapp/pom.xml
+    labels:
+    - konveyor.io/dep-source=open-source
+    - konveyor.io/language=java
+    prefix: file:///cache/m2/org/springframework/spring-expression/5.3.7
+  - name: org.springframework.spring-jcl
+    version: 5.3.7
+    type: compile
+    indirect: true
+    resolvedIdentifier: e1e7c14c73ae5fc616bb941ce8c1e7e62736cadf
+    extras:
+      artifactId: spring-jcl
+      baseDep:
+        extras:
+          artifactId: spring-data-jpa
+          groupId: org.springframework.data
+          pomPath: /shared/source/tackle-testapp/pom.xml
+        name: org.springframework.data.spring-data-jpa
+        version: 2.5.1
+      groupId: org.springframework
+      pomPath: /shared/source/tackle-testapp/pom.xml
+    labels:
+    - konveyor.io/dep-source=open-source
+    - konveyor.io/language=java
+    prefix: file:///cache/m2/org/springframework/spring-jcl/5.3.7
+  - name: org.springframework.spring-jdbc
+    version: 5.3.7
+    type: compile
+    resolvedIdentifier: a4f87a03116ecde96213642141eb95da05022f51
+    extras:
+      artifactId: spring-jdbc
+      groupId: org.springframework
+      pomPath: /shared/source/tackle-testapp/pom.xml
+    labels:
+    - konveyor.io/dep-source=open-source
+    - konveyor.io/language=java
+    prefix: file:///cache/m2/org/springframework/spring-jdbc/5.3.7
+  - name: org.springframework.spring-orm
+    version: 5.3.7
+    type: compile
+    indirect: true
+    resolvedIdentifier: cc6911f3194cb77d493aa626c661789926027446
+    extras:
+      artifactId: spring-orm
+      baseDep:
+        extras:
+          artifactId: spring-data-jpa
+          groupId: org.springframework.data
+          pomPath: /shared/source/tackle-testapp/pom.xml
+        name: org.springframework.data.spring-data-jpa
+        version: 2.5.1
+      groupId: org.springframework
+      pomPath: /shared/source/tackle-testapp/pom.xml
+    labels:
+    - konveyor.io/dep-source=open-source
+    - konveyor.io/language=java
+    prefix: file:///cache/m2/org/springframework/spring-orm/5.3.7
+  - name: org.springframework.spring-tx
+    version: 5.3.7
+    type: compile
+    indirect: true
+    resolvedIdentifier: c6df78e1d9b50b7063e4a196127d75ee9321f68b
+    extras:
+      artifactId: spring-tx
+      baseDep:
+        extras:
+          artifactId: spring-data-jpa
+          groupId: org.springframework.data
+          pomPath: /shared/source/tackle-testapp/pom.xml
+        name: org.springframework.data.spring-data-jpa
+        version: 2.5.1
+      groupId: org.springframework
+      pomPath: /shared/source/tackle-testapp/pom.xml
+    labels:
+    - konveyor.io/dep-source=open-source
+    - konveyor.io/language=java
+    prefix: file:///cache/m2/org/springframework/spring-tx/5.3.7
+  - name: org.springframework.spring-web
+    version: 5.3.7
+    type: compile
+    resolvedIdentifier: d9f78e0b045d90dc862cd4a39294a468b3cc6ba9
+    extras:
+      artifactId: spring-web
+      groupId: org.springframework
+      pomPath: /shared/source/tackle-testapp/pom.xml
+    labels:
+    - konveyor.io/dep-source=open-source
+    - konveyor.io/language=java
+    prefix: file:///cache/m2/org/springframework/spring-web/5.3.7
+  - name: org.springframework.spring-webmvc
+    version: 5.3.7
+    type: compile
+    resolvedIdentifier: d0f042bff56bb90beabc6ed5d062fb87c69e652a
+    extras:
+      artifactId: spring-webmvc
+      groupId: org.springframework
+      pomPath: /shared/source/tackle-testapp/pom.xml
+    labels:
+    - konveyor.io/dep-source=open-source
+    - konveyor.io/language=java
+    prefix: file:///cache/m2/org/springframework/spring-webmvc/5.3.7
+  - name: org.yaml.snakeyaml
+    version: "1.28"
+    type: compile
+    indirect: true
+    resolvedIdentifier: 3e38757e3eaf549cccd9bbdfa74b2930c177b8af
+    extras:
+      artifactId: snakeyaml
+      baseDep:
+        extras:
+          artifactId: spring-boot-starter-actuator
+          groupId: org.springframework.boot
+          pomPath: /shared/source/tackle-testapp/pom.xml
+        name: org.springframework.boot.spring-boot-starter-actuator
+        version: 2.5.0
+      groupId: org.yaml
+      pomPath: /shared/source/tackle-testapp/pom.xml
+    labels:
+    - konveyor.io/dep-source=open-source
+    - konveyor.io/language=java
+    prefix: file:///cache/m2/org/yaml/snakeyaml/1.28

--- a/hack/examples/issues-with-errors.yaml
+++ b/hack/examples/issues-with-errors.yaml
@@ -1,0 +1,2349 @@
+- name: cloud-readiness
+  description: This ruleset detects logging configurations that may be problematic when migrating an application to a cloud environment.
+  errors:
+    local-storage-00001: unable to ask for Konveyor rule entry
+  unmatched:
+  - embedded-cache-libraries-01000
+  - embedded-cache-libraries-02000
+  - embedded-cache-libraries-03000
+  - embedded-cache-libraries-04000
+  - embedded-cache-libraries-05000
+  - embedded-cache-libraries-06000
+  - embedded-cache-libraries-07000
+  - embedded-cache-libraries-08000
+  - embedded-cache-libraries-09000
+  - embedded-cache-libraries-10000
+  - embedded-cache-libraries-11000
+  - embedded-cache-libraries-12000
+  - embedded-cache-libraries-13000
+  - embedded-cache-libraries-14000
+  - embedded-cache-libraries-15000
+  - embedded-cache-libraries-16000
+  - java-corba-00000
+  - java-rmi-00000
+  - java-rmi-00000
+  - java-rmi-00001
+  - java-rpc-00000
+  - jca-00000
+  - jni-native-code-00000
+  - jni-native-code-00001
+  - local-storage-00002
+  - local-storage-00003
+  - local-storage-00004
+  - local-storage-00005
+  - local-storage-00006
+  - localhost-http-00001
+  - localhost-jdbc-00002
+  - localhost-ws-00003
+  - logging-0000
+  - logging-0000
+  - logging-0001
+  - logging-0001
+  - mail-00000
+  - session-00000
+  - session-00001
+  - socket-communication-00000
+  - socket-communication-00001
+- name: discovery-rules
+  tags:
+  - EJB XML
+  - Java Source
+  - Maven XML
+  - Properties
+  violations:
+    hardcoded-ip-address:
+      description: Hardcoded IP Address
+      category: mandatory
+      labels:
+      - discovery
+      - konveyor.io/target=cloud-readiness
+      - konveyor.io/target=discovery
+      incidents:
+      - uri: file:///shared/source/tackle-testapp/src/main/resources/persistence.properties
+        message: When migrating environments, hard-coded IP addresses may need to be modified or eliminated.
+        codeSnip: " 1   jdbc.driverClassName=oracle.jdbc.driver.OracleDriver\n 2   jdbc.url=jdbc:oracle:thin:@10.19.2.93:1521:xe\n 3   jdbc.user=customers\n 4   jdbc.password=customers\n 5   hibernate.hbm2ddl.auto=create-drop\n 6   hibernate.dialect=org.hibernate.dialect.OracleDialect\n 7  \n 8  # PostgreSQL\n 9  #jdbc.driverClassName=org.postgresql.Driver \n10  #jdbc.url=jdbc:postgresql://customers-postgresql:5432/customers\n11  #jdbc.user=customers\n12  #jdbc.password=customers\n13  #hibernate.hbm2ddl.auto=create-drop"
+        lineNumber: 2
+        variables:
+          matchingText: 10.19.2.93
+      effort: 1
+  insights:
+    discover-java-files:
+      description: Java source files
+      labels:
+      - discovery
+      - konveyor.io/include=always
+      - konveyor.io/target=discovery
+      - tag=Java Source
+      incidents:
+      - uri: file:///shared/source/tackle-testapp/src/main/java/io/konveyor/demo/ordermanagement/OrderManagementAppInitializer.java
+        message: ""
+      - uri: file:///shared/source/tackle-testapp/src/main/java/io/konveyor/demo/ordermanagement/config/PersistenceConfig.java
+        message: ""
+      - uri: file:///shared/source/tackle-testapp/src/main/java/io/konveyor/demo/ordermanagement/config/WebConfig.java
+        message: ""
+      - uri: file:///shared/source/tackle-testapp/src/main/java/io/konveyor/demo/ordermanagement/controller/CustomerController.java
+        message: ""
+      - uri: file:///shared/source/tackle-testapp/src/main/java/io/konveyor/demo/ordermanagement/exception/ResourceNotFoundException.java
+        message: ""
+      - uri: file:///shared/source/tackle-testapp/src/main/java/io/konveyor/demo/ordermanagement/exception/handler/ExceptionHandlingController.java
+        message: ""
+      - uri: file:///shared/source/tackle-testapp/src/main/java/io/konveyor/demo/ordermanagement/model/Customer.java
+        message: ""
+      - uri: file:///shared/source/tackle-testapp/src/main/java/io/konveyor/demo/ordermanagement/repository/CustomerRepository.java
+        message: ""
+      - uri: file:///shared/source/tackle-testapp/src/main/java/io/konveyor/demo/ordermanagement/service/CustomerService.java
+        message: ""
+    discover-maven-xml:
+      description: Maven XML file
+      labels:
+      - discovery
+      - konveyor.io/include=always
+      - konveyor.io/target=discovery
+      - tag=Maven XML
+      incidents:
+      - uri: file:///shared/source/tackle-testapp/pom.xml
+        message: ""
+    discover-properties-file:
+      description: Properties file
+      labels:
+      - discovery
+      - konveyor.io/include=always
+      - konveyor.io/target=discovery
+      - tag=Properties
+      incidents:
+      - uri: file:///shared/source/tackle-testapp/src/main/resources/persistence.properties
+        message: ""
+    windup-discover-ejb-configuration:
+      description: EJB XML Configuration
+      labels:
+      - discovery
+      - konveyor.io/include=always
+      - konveyor.io/target=discovery
+      - tag=EJB XML
+      incidents:
+      - uri: file:///shared/source/tackle-testapp/pom.xml
+        message: ""
+        codeSnip: " 1  <project xmlns=\"http://maven.apache.org/POM/4.0.0\"\n 2  \txmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"\n 3  \txsi:schemaLocation=\"http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd\">\n 4  \t<modelVersion>4.0.0</modelVersion>\n 5  \t<groupId>io.konveyor.demo</groupId>\n 6  \t<artifactId>customers-tomcat</artifactId>\n 7  \t<version>0.0.1-SNAPSHOT</version>\n 8  \n 9  \t<name>Order Management</name>\n10  \t<packaging>war</packaging>\n11  \t<description>Remaining services for the legacy Order Management application</description>\n12  \n13  \t<properties>\n14  \t\t<java.version>1.8</java.version>\n15  \t\t<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>"
+        lineNumber: 4
+        variables:
+          data: ""
+          innerText: "\n\t4.0.0\n\tio.konveyor.demo\n\tcustomers-tomcat\n\t0.0.1-SNAPSHOT\n\n\tOrder Management\n\twar\n\tRemaining services for the legacy Order Management application\n\n\t\n\t\t1.8\n\t\tUTF-8\n\t\tUTF-8\n\t\t${java.version}\n\t\t${java.version}\n\t\t5.3.7\n\t\t9.0.46\n\t\t2021.0.1\n\t\t5.4.32.Final\n\t\t6.2.0.Final\n\n\t\t42.2.20\n\t\t2.12.3\n\n\t\t3.8.1\n\t\t3.3.1\n\t\t3.2.0\n\n\t\n\n\t\n\t\t\n\t\t\t\n\t\t\t\tcom.fasterxml.jackson\n\t\t\t\tjackson-bom\n\t\t\t\t${jackson.version}\n\t\t\t\timport\n\t\t\t\tpom\n\t\t\t\n\t\t\t\n\t\t\t\torg.springframework.data\n\t\t\t\tspring-data-bom\n\t\t\t\t${spring-data.version}\n\t\t\t\timport\n\t\t\t\tpom\n\t\t\t\n\t\t\n\t\n\t\n\t\t\n\t\t\torg.apache.tomcat\n\t\t\ttomcat-servlet-api\n\t\t\t${tomcat.version}\n\t\t\tprovided\n\t\t\n\t\t\n\t\t\tcom.fasterxml.jackson.core\n\t\t\tjackson-core\n\t\t\n\t\t\n\t\t\tcom.fasterxml.jackson.core\n\t\t\tjackson-databind\n\t\t\n\t\t\n\t\t\torg.springframework.data\n\t\t\tspring-data-jpa\n\t\t\n\n\t\t\n\t\t\torg.springframework\n\t\t\tspring-jdbc\n\t\t\t${spring-framework.version}\n\t\t\n\t\t\n\t\t\torg.springframework\n\t\t\tspring-webmvc\n\t\t\t${spring-framework.version}\n\t\t\n\t\t\n\t\t\torg.springframework\n\t\t\tspring-web\n\t\t\t${spring-framework.version}\n\t\t\n\t\t\n\t\t\torg.springframework.boot\n\t\t\tspring-boot-starter-actuator\n\t\t\t2.5.0\n\t\t\n\t\t\n\t\t\torg.apache.tomcat\n\t\t\ttomcat-jdbc\n\t\t\t${tomcat.version}\n\t\t\truntime\n\t\t\n\t\t\n\t\t\torg.hibernate\n\t\t\thibernate-entitymanager\n\t\t\t${hibernate.version}\n\t\t\n\t\t\n\t\t\torg.hibernate.validator\n\t\t\thibernate-validator\n\t\t\t${hibernate-validator.version}\n\t\t\n\t\t\n\t\t\tch.qos.logback\n\t\t\tlogback-classic\n\t\t\t1.1.7\n\t\t\n\t\t\n\t\t\tcom.oracle.database.jdbc\n\t\t\tojdbc11\n\t\t\t21.1.0.0\n\t\t\n\t\t\n\t\t\torg.postgresql\n\t\t\tpostgresql\n\t\t\t42.2.23\n\t\t\n\t\t\n\t\t\n\t\t\tio.konveyor.demo\n\t\t\tconfig-utils\n\t\t\t1.0.0\n\t\t\n\n\t\n\t\n\t\t\n\t\t\t\n\t\t\t\torg.apache.maven.plugins\n\t\t\t\tmaven-compiler-plugin\n\t\t\t\t${maven-compiler-plugin.version}\n\t\t\t\n\t\t\t\n\t\t\t\torg.apache.maven.plugins\n\t\t\t\tmaven-war-plugin\n\t\t\t\t${maven-war-plugin.version}\n\t\t\t\t\n\t\t\t\t\tfalse\n\t\t\t\t\n\t\t\t\n\t\t\t\n\t\t\t\torg.apache.maven.plugins\n\t\t\t\tmaven-resources-plugin\n\t\t\t\t${maven-resources-plugin.version}\n\t\t\t\t\n\t\t\t\t\tUTF-8\n\t\t\t\t\n\t\t\t\n\t\t\n\t\n\t\n   \n     tackle-testapp\n     GitHub rromannissen Apache Maven Packages\n     https://maven.pkg.github.com/konveyor/tackle-testapp\n   \n\n\n\n"
+          matchingXML: <?xml?><project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd"><modelVersion>4.0.0</modelVersion><groupId>io.konveyor.demo</groupId><artifactId>customers-tomcat</artifactId><version>0.0.1-SNAPSHOT</version><name>Order Management</name><packaging>war</packaging><description>Remaining services for the legacy Order Management application</description><properties><java.version>1.8</java.version><project.build.sourceEncoding>UTF-8</project.build.sourceEncoding><project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding><maven.compiler.source>${java.version}</maven.compiler.source><maven.compiler.target>${java.version}</maven.compiler.target><spring-framework.version>5.3.7</spring-framework.version><tomcat.version>9.0.46</tomcat.version><spring-data.version>2021.0.1</spring-data.version><hibernate.version>5.4.32.Final</hibernate.version><hibernate-validator.version>6.2.0.Final</hibernate-validator.version><postgresql-driver.version>42.2.20</postgresql-driver.version><jackson.version>2.12.3</jackson.version><maven-compiler-plugin.version>3.8.1</maven-compiler-plugin.version><maven-war-plugin.version>3.3.1</maven-war-plugin.version><maven-resources-plugin.version>3.2.0</maven-resources-plugin.version></properties><dependencyManagement><dependencies><dependency><groupId>com.fasterxml.jackson</groupId><artifactId>jackson-bom</artifactId><version>${jackson.version}</version><scope>import</scope><type>pom</type></dependency><dependency><groupId>org.springframework.data</groupId><artifactId>spring-data-bom</artifactId><version>${spring-data.version}</version><scope>import</scope><type>pom</type></dependency></dependencies></dependencyManagement><dependencies><dependency><groupId>org.apache.tomcat</groupId><artifactId>tomcat-servlet-api</artifactId><version>${tomcat.version}</version><scope>provided</scope></dependency><dependency><groupId>com.fasterxml.jackson.core</groupId><artifactId>jackson-core</artifactId></dependency><dependency><groupId>com.fasterxml.jackson.core</groupId><artifactId>jackson-databind</artifactId></dependency><dependency><groupId>org.springframework.data</groupId><artifactId>spring-data-jpa</artifactId></dependency><dependency><groupId>org.springframework</groupId><artifactId>spring-jdbc</artifactId><version>${spring-framework.version}</version></dependency><dependency><groupId>org.springframework</groupId><artifactId>spring-webmvc</artifactId><version>${spring-framework.version}</version></dependency><dependency><groupId>org.springframework</groupId><artifactId>spring-web</artifactId><version>${spring-framework.version}</version></dependency><dependency><groupId>org.springframework.boot</groupId><artifactId>spring-boot-starter-actuator</artifactId><version>2.5.0</version></dependency><dependency><groupId>org.apache.tomcat</groupId><artifactId>tomcat-jdbc</artifactId><version>${tomcat.version}</version><scope>runtime</scope></dependency><dependency><groupId>org.hibernate</groupId><artifactId>hibernate-entitymanager</artifactId><version>${hibernate.version}</version></dependency><dependency><groupId>org.hibernate.validator</groupId><artifactId>hibernate-validator</artifactId><version>${hibernate-validator.version}</version></dependency><dependency><groupId>ch.qos.logback</groupId><artifactId>logback-classic</artifactId><version>1.1.7</version></dependency><dependency><groupId>com.oracle.database.jdbc</groupId><artifactId>ojdbc11</artifactId><version>21.1.0.0</version></dependency><dependency><groupId>org.postgresql</groupId><artifactId>postgresql</artifactId><version>42.2.23</version></dependency><!-- Corporate libraries --><dependency><groupId>io.konveyor.demo</groupId><artifactId>config-utils</artifactId><version>1.0.0</version></dependency></dependencies><build><plugins><plugin><groupId>org.apache.maven.plugins</groupId><artifactId>maven-compiler-plugin</artifactId><version>${maven-compiler-plugin.version}</version></plugin><plugin><groupId>org.apache.maven.plugins</groupId><artifactId>maven-war-plugin</artifactId><version>${maven-war-plugin.version}</version><configuration><failOnMissingWebXml>false</failOnMissingWebXml></configuration></plugin><plugin><groupId>org.apache.maven.plugins</groupId><artifactId>maven-resources-plugin</artifactId><version>${maven-resources-plugin.version}</version><configuration><encoding>UTF-8</encoding></configuration></plugin></plugins></build><distributionManagement><repository><id>tackle-testapp</id><name>GitHub rromannissen Apache Maven Packages</name><url>https://maven.pkg.github.com/konveyor/tackle-testapp</url></repository></distributionManagement></project>
+      - uri: file:///shared/source/tackle-testapp/rules/corporate-framework-config.windup.xml
+        message: ""
+        codeSnip: |2-
+           1  <?xml version="1.0"?>
+           2  <ruleset id="corporate-configuration"
+           3           xmlns="http://windup.jboss.org/schema/jboss-ruleset"
+           4           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           5           xsi:schemaLocation="http://windup.jboss.org/schema/jboss-ruleset http://windup.jboss.org/schema/jboss-ruleset/windup-jboss-ruleset.xsd">
+           6      <metadata>
+           7          <description>
+           8              This ruleset provides rules related to the corporate configuration frameworks.
+           9          </description>
+          10          <dependencies>
+          11            <addon id="org.jboss.windup.rules,windup-rules-javaee,3.0.0.Final"/>
+          12            <addon id="org.jboss.windup.rules,windup-rules-java,3.0.0.Final"/>
+          13          </dependencies>
+          14          <sourceTechnology id="traditional-corporate-framework"/>
+          15          <targetTechnology id="cloud-corporate-framework"/>
+          16          <tag>configuration</tag>
+        lineNumber: 5
+        variables:
+          data: ""
+          innerText: "\n\n    \n        \n            This ruleset provides rules related to the corporate configuration frameworks.\n        \n        \n          \n          \n        \n        \n        \n        configuration\n    \n    \n        \n            \n                \n                    VARIABLE_DECLARATION\n                \n            \n            \n                \n                    \n                        The legacy ApplicationConfiguration class is being used in this application. This is discouraged by the migration\n                        guidelines, and should be replaced by a more standard approach using Spring's @PropertySource annotation and Environment class:\n\n\n                        ```java\n                        @PropertySource(\"classpath:persistence.properties\")\n                        public class PersistenceConfig {\n                          @Autowired\n                          private Environment env;\n\n                          @Bean\n                          public DataSource dataSource() {\n                            final DriverManagerDataSource dataSource = new DriverManagerDataSource();\n                            dataSource.setDriverClassName(env.getProperty(\"jdbc.driverClassName\"));\n                            dataSource.setUrl(env.getProperty(\"jdbc.url\"));\n                            dataSource.setUsername(env.getProperty(\"jdbc.user\"));\n                            dataSource.setPassword(env.getProperty(\"jdbc.password\"));\n\n                            return dataSource;\n                          }\n                        }\n                        ```\n\n\n\n                        This allows externalizing the configuration in Kubernetes by injecting it as a ConfigMap or a Secret in the lib directory from the\n                        container running the Tomcat instance.\n                    \n                    \n                    \n                    \n                    configuration\n                \n            \n        \n      \n\n"
+          matchingXML: |-
+            <?xml version="1.0"?><ruleset id="corporate-configuration" xmlns="http://windup.jboss.org/schema/jboss-ruleset" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://windup.jboss.org/schema/jboss-ruleset http://windup.jboss.org/schema/jboss-ruleset/windup-jboss-ruleset.xsd"><metadata><description>This ruleset provides rules related to the corporate configuration frameworks.</description><dependencies><addon id="org.jboss.windup.rules,windup-rules-javaee,3.0.0.Final"></addon><addon id="org.jboss.windup.rules,windup-rules-java,3.0.0.Final"></addon></dependencies><sourceTechnology id="traditional-corporate-framework"></sourceTechnology><targetTechnology id="cloud-corporate-framework"></targetTechnology><tag>configuration</tag></metadata><rules><rule id="corporate-config-01000" xmlns="http://windup.jboss.org/schema/jboss-ruleset"><when><javaclass references="io.konveyor.demo.config.ApplicationConfiguration"><location>VARIABLE_DECLARATION</location></javaclass></when><perform><hint title="Legacy configuration with io.konveyor.demo.config.ApplicationConfiguration" effort="1" category-id="cloud-mandatory"><message>The legacy ApplicationConfiguration class is being used in this application. This is discouraged by the migration
+                                    guidelines, and should be replaced by a more standard approach using Spring&#39;s @PropertySource annotation and Environment class:
+
+
+                                    ```java
+                                    @PropertySource(&#34;classpath:persistence.properties&#34;)
+                                    public class PersistenceConfig {
+                                      @Autowired
+                                      private Environment env;
+
+                                      @Bean
+                                      public DataSource dataSource() {
+                                        final DriverManagerDataSource dataSource = new DriverManagerDataSource();
+                                        dataSource.setDriverClassName(env.getProperty(&#34;jdbc.driverClassName&#34;));
+                                        dataSource.setUrl(env.getProperty(&#34;jdbc.url&#34;));
+                                        dataSource.setUsername(env.getProperty(&#34;jdbc.user&#34;));
+                                        dataSource.setPassword(env.getProperty(&#34;jdbc.password&#34;));
+
+                                        return dataSource;
+                                      }
+                                    }
+                                    ```
+
+
+
+                                    This allows externalizing the configuration in Kubernetes by injecting it as a ConfigMap or a Secret in the lib directory from the
+                                    container running the Tomcat instance.</message><link title="Spring Documentation - PropertySource javadoc" href="https://docs.spring.io/spring-framework/docs/current/javadoc-api/org/springframework/context/annotation/PropertySource.html"></link><link title="Mkyong - Spring @PropertySource example" href="https://mkyong.com/spring/spring-propertysources-example/"></link><link title="Baeldung - Properties with Spring and Spring Boot" href="https://www.baeldung.com/properties-with-spring"></link><tag>configuration</tag></hint></perform></rule></rules></ruleset>
+      - uri: file:///shared/source/tackle-testapp/rules/no-target/test4.windup.xml
+        message: ""
+        codeSnip: " 1  <?xml version=\"1.0\"?>\n 2  <ruleset id=\"Test-004\" xmlns=\"http://windup.jboss.org/schema/jboss-ruleset\"\n 3  \txmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"\n 4  \txsi:schemaLocation=\"http://windup.jboss.org/schema/jboss-ruleset http://windup.jboss.org/schema/jboss-ruleset/windup-jboss-ruleset.xsd\">\n 5  \t<metadata>\n 6  \t\t<description>\n 7              \tThis is a description of rules. This is a template for new rulesets. Change this.\n 8          \t</description>\n 9  \t\t\t<!-- version ranges applied to from and to technologies -->\n10  \t\t<dependencies>\n11      \t\t\t<addon id=\"org.jboss.windup.rules,windup-rules-xml,3.0.0.Final\"/>\n12  \t\t</dependencies>\n13  \n14  \t</metadata>\n15  \t<rules>"
+        lineNumber: 4
+        variables:
+          data: ""
+          innerText: "\n\n\t\n\t\t\n            \tThis is a description of rules. This is a template for new rulesets. Change this.\n        \t\n\t\t\t\n\t\t\n    \t\t\t\n\t\t\n\n\t\n\t\n\t\t\n\t\t\t\n\t\t\t\n\t\t\t\t\n\n\t\t\t\n\t\t\t\n\t\t\t\n\t\t\t\t\n\t\t\t\t\tTest-002 Message markdown\n\t\t\t\t\tlink\n\t\t\t\t\ttag\n\t\t\t\t\n\n\t\t\t\n\t\t\n\t\n\n"
+          matchingXML: <?xml version="1.0"?><ruleset id="Test-004" xmlns="http://windup.jboss.org/schema/jboss-ruleset" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://windup.jboss.org/schema/jboss-ruleset http://windup.jboss.org/schema/jboss-ruleset/windup-jboss-ruleset.xsd"><metadata><description>This is a description of rules. This is a template for new rulesets. Change this.</description><!-- version ranges applied to from and to technologies --><dependencies><addon id="org.jboss.windup.rules,windup-rules-xml,3.0.0.Final"></addon></dependencies></metadata><rules><rule id="Test-004-00001"><!-- rule condition, when it could be fired --><when><file filename="AdministracionEfectivo-jpa{*}.jar"></file></when><!-- rule operation, what to do if it is fired --><perform><hint title="Test-002 Remote Exception" effort="0" category-id="potential"><message><![CDATA[Test-002 Message markdown]]></message><link href="http://nufc.com" title="Test-002 Test link">link</link><tag>tag</tag></hint></perform></rule></rules></ruleset>
+      - uri: file:///shared/source/tackle-testapp/rules/no-target/test5.windup.xml
+        message: ""
+        codeSnip: " 1  <?xml version=\"1.0\"?>\n 2  <ruleset id=\"Test-005\" xmlns=\"http://windup.jboss.org/schema/jboss-ruleset\"\n 3  \txmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"\n 4  \txsi:schemaLocation=\"http://windup.jboss.org/schema/jboss-ruleset http://windup.jboss.org/schema/jboss-ruleset/windup-jboss-ruleset.xsd\">\n 5  \t<metadata>\n 6  \t\t<description>\n 7              \tThis is a description of rules. This is a template for new rulesets. Change this.\n 8          \t</description>\n 9  \t\t\t<!-- version ranges applied to from and to technologies -->\n10  \t\t<dependencies>\n11      \t\t\t<addon id=\"org.jboss.windup.rules,windup-rules-xml,3.0.0.Final\"/>\n12  \t\t</dependencies>\n13  \n14  \t</metadata>\n15  \t<rules>"
+        lineNumber: 4
+        variables:
+          data: ""
+          innerText: "\n\n\t\n\t\t\n            \tThis is a description of rules. This is a template for new rulesets. Change this.\n        \t\n\t\t\t\n\t\t\n    \t\t\t\n\t\t\n\n\t\n\t\n\t\t\n\t\t\t\n\t\t\t\n\t\t\t\t\n\n\t\t\t\n\t\t\t\n\t\t\t\n\t\t\t\t\n\t\t\t\t\tTest-002 Message markdown\n\t\t\t\t\tlink\n\t\t\t\t\ttag\n\t\t\t\t\n\n\t\t\t\n\t\t\n\t\n\n"
+          matchingXML: <?xml version="1.0"?><ruleset id="Test-005" xmlns="http://windup.jboss.org/schema/jboss-ruleset" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://windup.jboss.org/schema/jboss-ruleset http://windup.jboss.org/schema/jboss-ruleset/windup-jboss-ruleset.xsd"><metadata><description>This is a description of rules. This is a template for new rulesets. Change this.</description><!-- version ranges applied to from and to technologies --><dependencies><addon id="org.jboss.windup.rules,windup-rules-xml,3.0.0.Final"></addon></dependencies></metadata><rules><rule id="Test-005-00001"><!-- rule condition, when it could be fired --><when><file filename="AdministracionEfectivo-jpa{*}.jar"></file></when><!-- rule operation, what to do if it is fired --><perform><hint title="Test-002 Remote Exception" effort="0" category-id="potential"><message><![CDATA[Test-002 Message markdown]]></message><link href="http://nufc.com" title="Test-002 Test link">link</link><tag>tag</tag></hint></perform></rule></rules></ruleset>
+      - uri: file:///shared/source/tackle-testapp/rules/test.windup.xml
+        message: ""
+        codeSnip: " 1  <?xml version=\"1.0\"?>\n 2  <ruleset id=\"Test-001\" xmlns=\"http://windup.jboss.org/schema/jboss-ruleset\"\n 3  \txmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"\n 4  \txsi:schemaLocation=\"http://windup.jboss.org/schema/jboss-ruleset http://windup.jboss.org/schema/jboss-ruleset/windup-jboss-ruleset.xsd\">\n 5  \t<metadata>\n 6  \t\t<description>\n 7              \tThis is a description of rules. This is a template for new rulesets. Change this.\n 8          \t</description>\n 9  \t\t\t<!-- version ranges applied to from and to technologies -->\n10  \t\t<dependencies>\n11      \t\t\t<addon id=\"org.jboss.windup.rules,windup-rules-xml,3.0.0.Final\"/>\n12  \t\t</dependencies>\n13  \n14  \t</metadata>\n15  \t<rules>"
+        lineNumber: 4
+        variables:
+          data: ""
+          innerText: "\n\n\t\n\t\t\n            \tThis is a description of rules. This is a template for new rulesets. Change this.\n        \t\n\t\t\t\n\t\t\n    \t\t\t\n\t\t\n\n\t\n\t\n\t\t\n\t\t\t\n\t\t\t\n\t\t\t\t\n\n\t\t\t\n\t\t\t\n\t\t\t\n\t\t\t\t\n\t\t\t\t\tTest-002 Message markdown\n\t\t\t\t\tlink\n\t\t\t\t\ttag\n\t\t\t\t\n\n\t\t\t\n\t\t\n\t\n\n"
+          matchingXML: <?xml version="1.0"?><ruleset id="Test-001" xmlns="http://windup.jboss.org/schema/jboss-ruleset" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://windup.jboss.org/schema/jboss-ruleset http://windup.jboss.org/schema/jboss-ruleset/windup-jboss-ruleset.xsd"><metadata><description>This is a description of rules. This is a template for new rulesets. Change this.</description><!-- version ranges applied to from and to technologies --><dependencies><addon id="org.jboss.windup.rules,windup-rules-xml,3.0.0.Final"></addon></dependencies></metadata><rules><rule id="Test-001-00001"><!-- rule condition, when it could be fired --><when><file filename="AdministracionEfectivo-jpa{*}.jar"></file></when><!-- rule operation, what to do if it is fired --><perform><hint title="Test-002 Remote Exception" effort="0" category-id="potential"><message><![CDATA[Test-002 Message markdown]]></message><link href="http://nufc.com" title="Test-002 Test link">link</link><tag>tag</tag></hint></perform></rule></rules></ruleset>
+      - uri: file:///shared/source/tackle-testapp/rules/test2.windup.xml
+        message: ""
+        codeSnip: " 1  <?xml version=\"1.0\"?>\n 2  <ruleset id=\"Test-002\" xmlns=\"http://windup.jboss.org/schema/jboss-ruleset\"\n 3  \txmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"\n 4  \txsi:schemaLocation=\"http://windup.jboss.org/schema/jboss-ruleset http://windup.jboss.org/schema/jboss-ruleset/windup-jboss-ruleset.xsd\">\n 5  \t<metadata>\n 6  \t\t<description>\n 7              \tThis is a description of rules. This is a template for new rulesets. Change this.\n 8          \t</description>\n 9  \t\t\t<!-- version ranges applied to from and to technologies -->\n10  \t\t<dependencies>\n11      \t\t\t<addon id=\"org.jboss.windup.rules,windup-rules-xml,3.0.0.Final\"/>\n12  \t\t</dependencies>\n13  \n14  \t</metadata>\n15  \t<rules>"
+        lineNumber: 4
+        variables:
+          data: ""
+          innerText: "\n\n\t\n\t\t\n            \tThis is a description of rules. This is a template for new rulesets. Change this.\n        \t\n\t\t\t\n\t\t\n    \t\t\t\n\t\t\n\n\t\n\t\n\t\t\n\t\t\t\n\t\t\t\n\t\t\t\t\n\n\t\t\t\n\t\t\t\n\t\t\t\n\t\t\t\t\n\t\t\t\t\tTest-002 Message markdown\n\t\t\t\t\tlink\n\t\t\t\t\ttag\n\t\t\t\t\n\n\t\t\t\n\t\t\n\t\n\n"
+          matchingXML: <?xml version="1.0"?><ruleset id="Test-002" xmlns="http://windup.jboss.org/schema/jboss-ruleset" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://windup.jboss.org/schema/jboss-ruleset http://windup.jboss.org/schema/jboss-ruleset/windup-jboss-ruleset.xsd"><metadata><description>This is a description of rules. This is a template for new rulesets. Change this.</description><!-- version ranges applied to from and to technologies --><dependencies><addon id="org.jboss.windup.rules,windup-rules-xml,3.0.0.Final"></addon></dependencies></metadata><rules><rule id="Test-002-00001"><!-- rule condition, when it could be fired --><when><file filename="AdministracionEfectivo-jpa{*}.jar"></file></when><!-- rule operation, what to do if it is fired --><perform><hint title="Test-002 Remote Exception" effort="0" category-id="potential"><message><![CDATA[Test-002 Message markdown]]></message><link href="http://nufc.com" title="Test-002 Test link">link</link><tag>tag</tag></hint></perform></rule></rules></ruleset>
+      - uri: file:///shared/source/tackle-testapp/rules/test3-nosuffix.xml
+        message: ""
+        codeSnip: " 1  <?xml version=\"1.0\"?>\n 2  <ruleset id=\"Test-003\" xmlns=\"http://windup.jboss.org/schema/jboss-ruleset\"\n 3  \txmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"\n 4  \txsi:schemaLocation=\"http://windup.jboss.org/schema/jboss-ruleset http://windup.jboss.org/schema/jboss-ruleset/windup-jboss-ruleset.xsd\">\n 5  \t<metadata>\n 6  \t\t<description>\n 7              \tThis is a description of rules. This is a template for new rulesets. Change this.\n 8          \t</description>\n 9  \t\t\t<!-- version ranges applied to from and to technologies -->\n10  \t\t<dependencies>\n11      \t\t\t<addon id=\"org.jboss.windup.rules,windup-rules-xml,3.0.0.Final\"/>\n12  \t\t</dependencies>\n13  \n14  \t</metadata>\n15  \t<rules>"
+        lineNumber: 4
+        variables:
+          data: ""
+          innerText: "\n\n\t\n\t\t\n            \tThis is a description of rules. This is a template for new rulesets. Change this.\n        \t\n\t\t\t\n\t\t\n    \t\t\t\n\t\t\n\n\t\n\t\n\t\t\n\t\t\t\n\t\t\t\n\t\t\t\t\n\n\t\t\t\n\t\t\t\n\t\t\t\n\t\t\t\t\n\t\t\t\t\tTest-002 Message markdown\n\t\t\t\t\tlink\n\t\t\t\t\ttag\n\t\t\t\t\n\n\t\t\t\n\t\t\n\t\n\n"
+          matchingXML: <?xml version="1.0"?><ruleset id="Test-003" xmlns="http://windup.jboss.org/schema/jboss-ruleset" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://windup.jboss.org/schema/jboss-ruleset http://windup.jboss.org/schema/jboss-ruleset/windup-jboss-ruleset.xsd"><metadata><description>This is a description of rules. This is a template for new rulesets. Change this.</description><!-- version ranges applied to from and to technologies --><dependencies><addon id="org.jboss.windup.rules,windup-rules-xml,3.0.0.Final"></addon></dependencies></metadata><rules><rule id="Test-003-00001"><!-- rule condition, when it could be fired --><when><file filename="AdministracionEfectivo-jpa{*}.jar"></file></when><!-- rule operation, what to do if it is fired --><perform><hint title="Test-002 Remote Exception" effort="0" category-id="potential"><message><![CDATA[Test-002 Message markdown]]></message><link href="http://nufc.com" title="Test-002 Test link">link</link><tag>tag</tag></hint></perform></rule></rules></ruleset>
+  unmatched:
+  - discover-license
+  - discover-manifest-file
+  - windup-discover-jpa-configuration
+  - windup-discover-spring-configuration
+  - windup-discover-web-configuration
+- name: eap6/java-ee/seam
+  description: This ruleset provides generic migration knowledge from the Seam 2 UI controls to pure JSF 2 UI Controls
+  insights:
+    generic-catchall-00700:
+      description: JBoss API reference
+      category: potential
+      labels:
+      - catchall
+      - jboss
+      - konveyor.io/source=java
+      - konveyor.io/source=javaee
+      - konveyor.io/source=soa
+      - konveyor.io/target=eap
+      - konveyor.io/target=eap6+
+      incidents:
+      - uri: file:///shared/source/tackle-testapp/src/main/java/io/konveyor/demo/ordermanagement/controller/CustomerController.java
+        message: '`org.jboss..logging.Logger;` reference found. No specific details available.'
+        codeSnip: " 1  package io.konveyor.demo.ordermanagement.controller;\n 2  \n 3  import org.jboss.logging.Logger;\n 4  import io.konveyor.demo.ordermanagement.exception.ResourceNotFoundException;\n 5  import io.konveyor.demo.ordermanagement.model.Customer;\n 6  import io.konveyor.demo.ordermanagement.service.CustomerService;\n 7  import org.springframework.beans.factory.annotation.Autowired;\n 8  import org.springframework.data.domain.Page;\n 9  import org.springframework.data.domain.Pageable;\n10  import org.springframework.http.MediaType;\n11  import org.springframework.web.bind.annotation.GetMapping;\n12  import org.springframework.web.bind.annotation.PathVariable;\n13  import org.springframework.web.bind.annotation.RequestMapping;"
+        lineNumber: 3
+        variables:
+          file: file:///shared/source/tackle-testapp/src/main/java/io/konveyor/demo/ordermanagement/controller/CustomerController.java
+          kind: Module
+          name: org.jboss.logging.Logger
+          package: io.konveyor.demo.ordermanagement.controller
+          packageRemainder: logging.
+          subpackage: jboss.
+          type: Logger;
+      - uri: file:///shared/source/tackle-testapp/src/main/java/io/konveyor/demo/ordermanagement/exception/handler/ExceptionHandlingController.java
+        message: '`org.jboss..logging.Logger;` reference found. No specific details available.'
+        codeSnip: " 1  package io.konveyor.demo.ordermanagement.exception.handler;\n 2  \n 3  \n 4  import org.jboss.logging.Logger;\n 5  import io.konveyor.demo.ordermanagement.exception.ResourceNotFoundException;\n 6  import org.springframework.http.HttpStatus;\n 7  import org.springframework.web.bind.annotation.ControllerAdvice;\n 8  import org.springframework.web.bind.annotation.ExceptionHandler;\n 9  import org.springframework.web.bind.annotation.ResponseStatus;\n10  \n11  @ControllerAdvice\n12  public class ExceptionHandlingController {\n13  \t\n14  \tprivate static Logger logger = Logger.getLogger( ExceptionHandlingController.class.getName() );"
+        lineNumber: 4
+        variables:
+          file: file:///shared/source/tackle-testapp/src/main/java/io/konveyor/demo/ordermanagement/exception/handler/ExceptionHandlingController.java
+          kind: Module
+          name: org.jboss.logging.Logger
+          package: io.konveyor.demo.ordermanagement.exception.handler
+          packageRemainder: logging.
+          subpackage: jboss.
+          type: Logger;
+      - uri: file:///shared/source/tackle-testapp/src/main/java/io/konveyor/demo/ordermanagement/service/CustomerService.java
+        message: '`org.jboss..logging.Logger;` reference found. No specific details available.'
+        codeSnip: " 1  package io.konveyor.demo.ordermanagement.service;\n 2  \n 3  \n 4  import org.jboss.logging.Logger;\n 5  import io.konveyor.demo.ordermanagement.model.Customer;\n 6  import io.konveyor.demo.ordermanagement.repository.CustomerRepository;\n 7  import org.springframework.beans.factory.annotation.Autowired;\n 8  import org.springframework.data.domain.Page;\n 9  import org.springframework.data.domain.Pageable;\n10  import org.springframework.stereotype.Service;\n11  import org.springframework.transaction.annotation.Transactional;\n12  \n13  @Service\n14  @Transactional"
+        lineNumber: 4
+        variables:
+          file: file:///shared/source/tackle-testapp/src/main/java/io/konveyor/demo/ordermanagement/service/CustomerService.java
+          kind: Module
+          name: org.jboss.logging.Logger
+          package: io.konveyor.demo.ordermanagement.service
+          packageRemainder: logging.
+          subpackage: jboss.
+          type: Logger;
+      effort: 0
+  unmatched:
+  - commonj-01000
+  - commonj-02000
+  - commonj-03000
+  - commonj-04000
+  - commonj-05000
+  - commonj-06000
+  - commonj-07000
+  - eap4-eap6-25000
+  - eap4-eap6-26000
+  - eap4-eap6-27000
+  - eap4-eap6-28000
+  - eap4-eap6-29000
+  - eap4-eap6-30000
+  - eap4-eap6-31000
+  - eap4-eap6-32000
+  - eap4-eap6-33000
+  - eap4-eap6-34000
+  - eap4-eap6-35000
+  - eap4-eap6-36000
+  - eap4-eap6-37000
+  - eap4-eap6-38000
+  - eap4-eap6-39000
+  - eap4-eap6-40000
+  - eap4-eap6-41000
+  - eap4-eap6-42000
+  - generic-catchall-00000
+  - generic-catchall-00001
+  - generic-catchall-00002
+  - generic-catchall-00003
+  - generic-catchall-00100
+  - generic-catchall-00200
+  - generic-catchall-00300
+  - generic-catchall-00400
+  - generic-catchall-00500
+  - generic-catchall-00600
+  - generic-catchall-00900
+  - java-ee-jaxrpc-00000
+  - jotm-00001
+  - jrun-catchall-00000
+  - jrun-catchall-00001
+  - jsp-01000
+  - log4j-01000
+  - log4j-02000
+  - log4j-03000
+  - xml-glassfish-01000
+  - xml-glassfish-02000
+  - xml-glassfish-03000
+  - xml-jonas-01000
+  - xml-jrun-01000
+  - xml-jrun-02000
+  - xml-orion-01000
+  - xml-orion-02000
+  - xml-orion-03000
+  - xml-resin-01000
+  - xml-webservices-01000
+  - xml-webservices-02000
+  - xml-webservices-03000
+  - xml-webservices-04000
+  - xml-webservices-05000
+  - xml-webservices-06000
+  - xml-webservices-06001
+  - xml-webservices-07000
+  - xml-webservices-08000
+  - xml-webservices-09000
+  - xml-webservices-10000
+  skipped:
+  - environment-dependent-calls-01000
+  - environment-dependent-calls-02000
+  - environment-dependent-calls-03000
+  - environment-dependent-calls-03500
+  - environment-dependent-calls-04000
+  - environment-dependent-calls-04001
+  - environment-dependent-calls-05000
+  - jboss-eap5-7-xml-10000
+  - jboss-eap5-java-01000
+  - jboss-eap5-java-02000
+  - jboss-eap5-java-04000
+  - jboss-eap5-java-05000
+  - jboss-eap5-java-06000
+  - jboss-eap5-java-07000
+  - jboss-eap5-java-08000
+  - jboss-eap5-java-08100
+  - jboss-eap5-java-08200
+  - jboss-eap5-java-08300
+  - jboss-eap5-java-08400
+  - jboss-eap5-java-08500
+  - jboss-eap5-java-08600
+  - jboss-eap5-java-08700
+  - jboss-eap5-java-08800
+  - jboss-eap5-java-08900
+  - jboss-eap5-java-09000
+  - jboss-eap5-java-09100
+  - jboss-eap5-xml-01000
+  - jboss-eap5-xml-02000
+  - jboss-eap5-xml-03000
+  - jboss-eap5-xml-05000
+  - jboss-eap5-xml-06000
+  - jboss-eap5-xml-07000
+  - jboss-eap5-xml-08000
+  - jboss-eap5-xml-09000
+  - jboss-eap5-xml-11000
+  - jboss-eap5-xml-12000
+  - jboss-eap5-xml-13000
+  - jboss-eap5-xml-14000
+  - jboss-eap5-xml-16000
+  - jboss-eap5-xml-17000
+  - jboss-eap5-xml-18000
+  - jboss-eap5-xml-20000
+  - resteasy-eap5-000001
+  - seam-java-00000
+  - seam-java-00010
+  - seam-java-00030
+  - seam-java-00040
+  - seam-java-00050
+  - seam-java-00060
+  - seam-java-00061
+  - seam-java-00070
+  - seam-java-00071
+  - seam-java-00080
+  - seam-java-00090
+  - seam-java-00091
+  - seam-java-00100
+  - seam-java-00110
+  - seam-java-00120
+  - seam-java-00130
+  - seam-java-00140
+  - seam-java-00150
+  - seam-java-00160
+  - seam-java-00170
+  - seam-java-00180
+  - seam-java-00190
+  - seam-java-00200
+  - seam-java-00210
+  - seam-java-00220
+  - seam-java-00230
+  - seam-java-00240
+  - seam-java-00250
+  - seam-java-00260
+  - seam-java-00270
+  - seam-ui-jsf-00001
+  - seam-ui-jsf-00001-01
+  - seam-ui-jsf-00002
+  - seam-ui-jsf-01000
+  - seam-ui-jsf-01001
+  - seam-ui-jsf-01002
+  - seam-ui-jsf-01003
+  - seam-ui-jsf-01004
+  - seam-ui-jsf-01005
+  - seam-ui-jsf-01006
+  - seam-ui-jsf-01007
+  - seam-ui-jsf-01008
+  - seam-ui-jsf-01009
+  - seam-ui-jsf-01010
+  - seam-ui-jsf-01011
+  - seam-ui-jsf-01012
+  - seam-ui-jsf-01013
+  - seam-ui-jsf-01014
+  - seam-ui-jsf-01015
+  - seam-ui-jsf-01016
+  - seam-ui-jsf-01017
+  - seam-ui-jsf-01018
+  - seam-ui-jsf-01019
+  - seam-ui-jsf-01020
+  - seam-ui-jsf-01021
+  - seam-ui-jsf-01022
+  - seam-ui-jsf-01023
+  - seam-ui-jsf-01024
+  - seam-ui-jsf-01025
+  - seam-ui-jsf-01026
+  - seam-ui-jsf-01027
+  - seam-ui-jsf-01028
+  - seam-ui-jsf-01029
+- name: eap7/weblogic/tests/data
+  errors:
+    jax-ws-00000: unable to ask for Konveyor rule entry
+    jboss-eap5and6to7-java-09000: unable to ask for Konveyor rule entry
+    weblogic-catchall-02000: unable to ask for Konveyor rule entry
+    weblogic-catchall-06500: unable to ask for Konveyor rule entry
+  unmatched:
+  - base64-01000
+  - eap6-08000
+  - eap6-08001
+  - eap6-08002
+  - eap6-11000
+  - eap6-12000
+  - eap6-xml-05000
+  - eap6-xml-06000
+  - eap7-websphere-xml-01000
+  - eap7-websphere-xml-02000
+  - eap7-websphere-xml-03500
+  - eap7-websphere-xml-06000
+  - eap7-websphere-xml-07000
+  - eap7-websphere-xml-08000
+  - eap7-websphere-xml-09000
+  - elytron-eap71-00000
+  - elytron-eap71-00010
+  - hibernate4-xml-00001
+  - hibernate4-xml-00002
+  - hibernate4-xml-00003
+  - hibernate4-xml-00004
+  - hibernate4-xml-00005
+  - jaxrpc-00000
+  - jboss-eap5-7-java-02000
+  - jboss-eap5-7-java-03000
+  - jboss-eap5-7-java-05000
+  - jboss-eap5-7-java-06000
+  - jboss-eap5-7-java-07000
+  - jboss-eap5-7-java-08000
+  - jboss-eap5-7-java-08100
+  - jboss-eap5-7-java-08200
+  - jboss-eap5-7-java-08300
+  - jboss-eap5-7-java-08400
+  - jboss-eap5-7-java-08500
+  - jboss-eap5-7-java-08600
+  - jboss-eap5-7-java-08700
+  - jboss-eap5-7-java-08800
+  - jboss-eap5-7-java-08900
+  - jboss-eap5-7-java-09000
+  - jboss-eap5-7-java-09100
+  - jboss-eap5-7-xml-01000
+  - jboss-eap5-7-xml-02000
+  - jboss-eap5-7-xml-10000
+  - jboss-eap5-7-xml-10000
+  - jboss-eap5-7-xml-13000
+  - jboss-eap5-7-xml-14000
+  - jboss-eap5-7-xml-16000
+  - jboss-eap5-7-xml-16000
+  - jboss-eap5and6to7-java-01000
+  - jboss-eap5and6to7-java-02000
+  - jboss-eap5and6to7-java-03000
+  - jboss-eap5and6to7-java-04000
+  - jboss-eap5and6to7-java-05000
+  - jboss-eap5and6to7-java-06000
+  - jboss-eap5and6to7-java-07000
+  - jboss-eap5and6to7-java-08000
+  - jboss-eap5and6to7-xml-05000
+  - jboss-eap5and6to7-xml-06000
+  - jboss-eap5and6to7-xml-07000
+  - jboss-eap5and6to7-xml-09000
+  - jboss-eap5and6to7-xml-12000
+  - jboss-eap5and6to7-xml-17000
+  - jboss-eap5and6to7-xml-18000
+  - jboss-eap5and6to7-xml-31000
+  - jboss-eap5and6to7-xml-31500
+  - jboss-eap5and6to7-xml-32000
+  - jboss-eap5and6to7-xml-33000
+  - jboss-eap5and6to7-xml-34000
+  - jboss-eap5and6to7-xml-37000
+  - jboss-eap5and6to7-xml-38000
+  - jboss-eap5and6to7-xml-38001
+  - jboss-eap5and6to7-xml-38002
+  - jboss-eap5and6to7-xml-38003
+  - jboss-eap5and6to7-xml-38004
+  - jboss-eap5and6to7-xml-38005
+  - jboss-eap5and6to7-xml-38006
+  - jboss-eap5and6to7-xml-38007
+  - jboss-eap5and6to7-xml-39000
+  - jboss-eap5and6to7-xml-40000
+  - maven-javax-to-jakarta-00001
+  - maven-javax-to-jakarta-00002
+  - maven-javax-to-jakarta-00003
+  - maven-javax-to-jakarta-00004
+  - maven-javax-to-jakarta-00005
+  - maven-javax-to-jakarta-00006
+  - maven-javax-to-jakarta-00007
+  - maven-javax-to-jakarta-00008
+  - maven-javax-to-jakarta-00010
+  - maven-javax-to-jakarta-00011
+  - maven-javax-to-jakarta-00012
+  - maven-javax-to-jakarta-00013
+  - maven-javax-to-jakarta-00014
+  - maven-javax-to-jakarta-00015
+  - maven-javax-to-jakarta-00016
+  - maven-javax-to-jakarta-00017
+  - resteasy-eap5and6to7-000018
+  - weblogic-catchall-01000
+  - weblogic-catchall-03000
+  - weblogic-catchall-06000
+  - weblogic-eap7-01000
+  - weblogic-eap7-01000
+  - weblogic-eap7-016000
+  - weblogic-eap7-017000
+  - weblogic-eap7-02000
+  - weblogic-eap7-03000
+  - weblogic-eap7-04000
+  - weblogic-eap7-05000
+  - weblogic-eap7-06000
+  - weblogic-eap7-07000
+  - weblogic-eap7-08000
+  - weblogic-eap7-09000
+  - weblogic-eap7-10000
+  - weblogic-eap7-11000
+  - weblogic-eap7-12000
+  - weblogic-eap7-13000
+  - weblogic-eap7-15000
+  - weblogic-ejb-01000
+  - weblogic-ejb-02000
+  - weblogic-ejb-03000
+  - weblogic-ejb-04000
+  - weblogic-jms-eap7-00000
+  - weblogic-jms-eap7-01000
+  - weblogic-jms-eap7-02000
+  - weblogic-jms-eap7-03000
+  - weblogic-jms-eap7-04000
+  - weblogic-jms-eap7-05000
+  - weblogic-jms-eap7-06000
+  - weblogic-jms-eap7-07000
+  - weblogic-jms-eap7-08000
+  - weblogic-services-eap7-01000
+  - weblogic-services-eap7-02000
+  - weblogic-services-eap7-03000
+  - weblogic-webapp-eap7-01000
+  - weblogic-webapp-eap7-02000
+  - weblogic-webapp-eap7-03000
+  - weblogic-webapp-eap7-04000
+  - weblogic-webapp-eap7-05000
+  - weblogic-webapp-eap7-06000
+  - weblogic-webapp-eap7-07000
+  - weblogic-webapp-eap7-08000
+  - weblogic-webapp-eap7-09000
+  - weblogic-webservices-07000
+  - weblogic-webservices-eap7-01000
+  - weblogic-webservices-eap7-02000
+  - weblogic-webservices-eap7-03000
+  - weblogic-webservices-eap7-04000
+  - weblogic-webservices-eap7-05000
+  - weblogic-webservices-eap7-06000
+  - weblogic-xml-descriptor-19000
+  - weblogic-xml-descriptor-eap7-01000
+  - weblogic-xml-descriptor-eap7-02000
+  - weblogic-xml-descriptor-eap7-03000
+  - weblogic-xml-descriptor-eap7-04000
+  - weblogic-xml-descriptor-eap7-06001
+  - weblogic-xml-descriptor-eap7-07000
+  - weblogic-xml-descriptor-eap7-08000
+  - weblogic-xml-descriptor-eap7-09000
+  - weblogic-xml-descriptor-eap7-10000
+  - weblogic-xml-descriptor-eap7-11000
+  - weblogic-xml-descriptor-eap7-12000
+  - weblogic-xml-descriptor-eap7-13000
+  - weblogic-xml-descriptor-eap7-14000
+  - weblogic-xml-descriptor-eap7-15000
+  - weblogic-xml-descriptor-eap7-16000
+  - weblogic-xml-descriptor-eap7-17000
+  - weblogic-xml-descriptor-eap7-18000
+  - websphere-catchall-00000
+  - websphere-catchall-00001
+  - websphere-catchall-db2-00000
+  - websphere-jms-eap7-00000
+  - websphere-jms-eap7-01000
+  - websphere-jms-eap7-02000
+  - websphere-jms-eap7-02500
+  - websphere-jms-eap7-03000
+  - websphere-jms-eap7-04000
+  - websphere-mq-eap7-00000
+  - websphere-mq-eap7-01000
+  - websphere-mq-eap7-01000
+  - websphere-mq-eap7-02000
+  - websphere-mq-eap7-02000
+  - websphere-mqe-eap7-00000
+  - websphere-mqe-eap7-01000
+  - websphere-mqe-eap7-02000
+  - websphere-mqe-eap7-03000
+  - websphere-mqe-eap7-04000
+  - websphere-other-eap7-01000
+  - websphere-other-eap7-02000
+  - ws-security-00000
+  - ws-security-00001
+  - ws-security-00002
+  skipped:
+  - deprecated-singletonpolicy-00001
+  - embedded-framework-libraries-01000
+  - embedded-framework-libraries-02000
+  - embedded-framework-libraries-04000
+  - embedded-framework-libraries-05000
+  - embedded-framework-libraries-06000
+  - hibernate4-00001
+  - hibernate4-00002
+  - hibernate4-00003
+  - hibernate4-00004
+  - hibernate4-00005
+  - hibernate4-00006
+  - hibernate4-00007
+  - hibernate4-00008
+  - hibernate4-00009
+  - hibernate4-00010
+  - hibernate4-00011
+  - hibernate4-00012
+  - hibernate4-00013
+  - hibernate4-00014
+  - hibernate4-00015
+  - hibernate4-00016
+  - hibernate4-00017
+  - hibernate4-00018
+  - hibernate4-00021
+  - hibernate4-00022
+  - hibernate4-00023
+  - hibernate4-00024
+  - hibernate4-00025
+  - hibernate4-00026
+  - hibernate4-00027
+  - hibernate4-00028
+  - hibernate4-00030
+  - hibernate4-00031
+  - hibernate4-00032
+  - hibernate4-00033
+  - hibernate4-00034
+  - hibernate4-00035
+  - hibernate4-00036
+  - hibernate4-00037
+  - hibernate4-00038
+  - hibernate4-00039
+  - hibernate4-00040
+  - hibernate50-51-00000
+  - hibernate50-51-00100
+  - hibernate51-53-00001
+  - hibernate51-53-00100
+  - hibernate51-53-00300
+  - hibernate51-53-00400
+  - hibernate51-53-00401
+  - hibernate51-53-00402
+  - hibernate51-53-00403
+  - hibernate51-53-00404
+  - hibernate51-53-00405
+  - hibernate51-53-00406
+  - hibernate51-53-00407
+  - hibernate51-53-00500
+  - hibernate51-53-00600
+  - hibernate51-53-00700
+  - hibernate51-53-00701
+  - hibernate51-53-00702
+  - hibernate51-53-00800
+  - hibernate51-53-01000
+  - hibernate51-53-01001
+  - hibernate51-53-01100
+  - hibernate51-53-01200
+  - hsearch-00000
+  - hsearch-00001
+  - hsearch-00002
+  - hsearch-00003
+  - hsearch-00004
+  - hsearch-00005
+  - hsearch-00006
+  - hsearch-00007
+  - hsearch-00008
+  - hsearch-00009
+  - hsearch-00010
+  - hsearch-00011
+  - hsearch-00100
+  - hsearch-00101
+  - hsearch-00103
+  - hsearch-00104
+  - hsearch-00106
+  - hsearch-00107
+  - hsearch-00108
+  - hsearch-00109
+  - hsearch-00110
+  - hsearch-00111
+  - hsearch-00112
+  - hsearch-00113
+  - hsearch-00114
+  - hsearch-00115
+  - hsearch-00116
+  - hsearch-00117
+  - hsearch-00118
+  - hsearch-00119
+  - hsearch-00200
+  - hsearch-00201
+  - hsearch-00210
+  - hsearch-00211
+  - hsearch-00213
+  - hsearch-00214
+  - hsearch-00215
+  - hsearch-00216
+  - hsearch-00217
+  - hsearch-00218
+  - hsearch-00219
+  - hsearch-00220
+  - hsearch-00221
+  - hsearch-00222
+  - hsearch-00224
+  - hsearch-00225
+  - hsearch-00226
+  - hsearch-00227
+  - hsearch-00228
+  - hsearch-00229
+  - hsearch-00230
+  - hsearch-00231
+  - hsearch-00232
+  - hsearch-00233
+  - hsearch-00234
+  - hsearch-00235
+  - hsearch-00236
+  - hsearch-00237
+  - hsearch-00238
+  - hsearch-00239
+  - hsearch-00240
+  - jboss-eap4and5to6and7-java-01000
+  - jboss-eap4and5to6and7-java-02000
+  - jboss-eap4and5to6and7-java-03000
+  - jboss-eap4and5to6and7-xml-01000
+  - jboss-eap4and5to6and7-xml-02000
+  - jboss-eap4and5to6and7-xml-03000
+  - jboss-eap4and5to6and7-xml-04000
+  - jboss-eap4and5to6and7-xml-05000
+  - jboss-eap4and5to6and7-xml-06000
+  - jboss-eap4and5to6and7-xml-07000
+  - maven-artemis-jms-client-00001
+  - maven-jboss-rmi-api_1.0_spec-00001
+  - microprofile_removed_from_eap-00001
+  - microprofile_removed_from_eap-00001-01
+  - microprofile_removed_from_eap-00002
+  - microprofile_removed_from_eap-00003
+  - microprofile_removed_from_eap-00004
+  - move-to-microprofile-rest-client-1.3-00001
+  - picketlink25-00000
+  - resteasy-eap6-000001
+  - resteasy-eap6-000002
+  - resteasy-eap6-000003
+  - resteasy-eap6-000004
+  - resteasy-eap6-000005
+  - resteasy-eap6-000006
+  - resteasy-eap6-000007
+  - resteasy-eap6-000008
+  - resteasy-eap6-000009
+  - resteasy-eap6-000010
+  - resteasy-eap6-000011
+  - resteasy-eap6-000012
+  - resteasy-eap6-000013
+  - resteasy-eap6-000014
+  - resteasy-eap6-000015
+  - resteasy-eap6-000017
+  - resteasy-eap6-000019
+  - resteasy-eap6-000020
+  - resteasy-eap6-000021
+  - resteasy-eap6-000022
+  - resteasy-eap6-000023
+  - resteasy-eap6-000024
+  - resteasy-eap6-000025
+  - resteasy-eap6-000029
+  - resteasy-eap6-000030
+  - resteasy-eap6-000032
+  - resteasy-eap6-000101
+  - resteasy-eap6-000103
+  - resteasy-eap6-000104
+  - resteasy-eap6-000105
+  - resteasy-eap6-000106
+  - resteasy-eap6-000107
+  - resteasy-eap6-000118
+  - resteasy-eap6-000119
+  - resteasy-eap6-000120
+  - resteasy-eap6-000121
+  - resteasy-eap6-000122
+  - resteasy-eap6-000123
+  - resteasy-eap6-000125
+  - resteasy-eap6-000126
+  - resteasy-eap6-000127
+  - resteasy-eap6-000128
+  - resteasy-eap6-000129
+  - resteasy-eap6-000130
+  - resteasy-eap6-000131
+  - resteasy-eap6-000140
+  - resteasy-eap6-000141
+  - resteasy-eap6-000142
+  - resteasy30-36-00001
+  - singleton-sessionbean-00001
+- name: eap8/eap7
+  description: This ruleset provides analysis of Java EE applications that need to change certain CDI-related method calls.
+  violations:
+    eap8-xml-binding-00008:
+      description: Outdated JAXB dependency
+      category: mandatory
+      labels:
+      - eap8
+      - konveyor.io/source=eap
+      - konveyor.io/source=eap6
+      - konveyor.io/source=eap7
+      - konveyor.io/target=eap
+      - konveyor.io/target=eap8+
+      incidents:
+      - uri: file:///shared/source/tackle-testapp/pom.xml
+        message: Pom dependency to outdated xml binding version must be updated to Jakarta XML Binding 4.0 for EAP8.
+        codeSnip: " 90  \t\t\t<version>2.5.0</version>\n 91  \t\t</dependency>\n 92  \t\t<dependency>\n 93  \t\t\t<groupId>org.apache.tomcat</groupId>\n 94  \t\t\t<artifactId>tomcat-jdbc</artifactId>\n 95  \t\t\t<version>${tomcat.version}</version>\n 96  \t\t\t<scope>runtime</scope>\n 97  \t\t</dependency>\n 98  \t\t<dependency>\n 99  \t\t\t<groupId>org.hibernate</groupId>\n100  \t\t\t<artifactId>hibernate-entitymanager</artifactId>\n101  \t\t\t<version>${hibernate.version}</version>\n102  \t\t</dependency>\n103  \t\t<dependency>\n104  \t\t\t<groupId>org.hibernate.validator</groupId>\n105  \t\t\t<artifactId>hibernate-validator</artifactId>\n106  \t\t\t<version>${hibernate-validator.version}</version>\n107  \t\t</dependency>\n108  \t\t<dependency>\n109  \t\t\t<groupId>ch.qos.logback</groupId>\n110  \t\t\t<artifactId>logback-classic</artifactId>"
+        lineNumber: 99
+        variables:
+          name: org.glassfish.jaxb.jaxb-runtime
+          version: 2.3.1
+      links:
+      - url: https://access.redhat.com/articles/6980265#jaxb
+        title: 'JBoss EAP Application Migration from Jakarta EE 8 to EE 10: Jakarta XML Binding'
+      - url: https://jakarta.ee/specifications/xml-binding/4.0/jakarta-xml-binding-spec-4.0.html
+        title: Jakarta XML Binding 4.0 specification
+      effort: 1
+    hibernate-search-6.1-00010:
+      description: Hibernate Search 6.1.* now requires using Hibernate ORM versions from the 5.6.x family.
+      category: mandatory
+      labels:
+      - eap8
+      - hibernate
+      - konveyor.io/source
+      - konveyor.io/target=eap
+      - konveyor.io/target=eap8+
+      - konveyor.io/target=hibernate
+      - konveyor.io/target=hibernate6.1+
+      - konveyor.io/target=quarkus
+      - konveyor.io/target=quarkus3+
+      incidents:
+      - uri: file:///shared/source/tackle-testapp/pom.xml
+        message: Hibernate Search 6.1.x now requires using Hibernate ORM versions from the 5.6.x family.
+        codeSnip: " 90  \t\t\t<version>2.5.0</version>\n 91  \t\t</dependency>\n 92  \t\t<dependency>\n 93  \t\t\t<groupId>org.apache.tomcat</groupId>\n 94  \t\t\t<artifactId>tomcat-jdbc</artifactId>\n 95  \t\t\t<version>${tomcat.version}</version>\n 96  \t\t\t<scope>runtime</scope>\n 97  \t\t</dependency>\n 98  \t\t<dependency>\n 99  \t\t\t<groupId>org.hibernate</groupId>\n100  \t\t\t<artifactId>hibernate-entitymanager</artifactId>\n101  \t\t\t<version>${hibernate.version}</version>\n102  \t\t</dependency>\n103  \t\t<dependency>\n104  \t\t\t<groupId>org.hibernate.validator</groupId>\n105  \t\t\t<artifactId>hibernate-validator</artifactId>\n106  \t\t\t<version>${hibernate-validator.version}</version>\n107  \t\t</dependency>\n108  \t\t<dependency>\n109  \t\t\t<groupId>ch.qos.logback</groupId>\n110  \t\t\t<artifactId>logback-classic</artifactId>"
+        lineNumber: 99
+        variables:
+          name: org.hibernate.hibernate-core
+          version: 5.4.32.Final
+      links:
+      - url: https://docs.jboss.org/hibernate/search/6.1/migration/html_single/#requirements
+        title: Hibernate Search 6.1 - Migration Guide from 6.0
+      effort: 1
+    javax-to-jakarta-dependencies-00004:
+      description: javax.activation groupId has been replaced by jakarta.activation
+      category: mandatory
+      labels:
+      - konveyor.io/source
+      - konveyor.io/target=eap
+      - konveyor.io/target=eap8
+      - konveyor.io/target=jakarta-ee
+      - konveyor.io/target=jakarta-ee9+
+      - konveyor.io/target=jws
+      - konveyor.io/target=jws6+
+      incidents:
+      - uri: file:///shared/source/tackle-testapp/pom.xml
+        message: Replace dependency groupId `javax.activation` with `jakarta.activation`
+        codeSnip: " 90  \t\t\t<version>2.5.0</version>\n 91  \t\t</dependency>\n 92  \t\t<dependency>\n 93  \t\t\t<groupId>org.apache.tomcat</groupId>\n 94  \t\t\t<artifactId>tomcat-jdbc</artifactId>\n 95  \t\t\t<version>${tomcat.version}</version>\n 96  \t\t\t<scope>runtime</scope>\n 97  \t\t</dependency>\n 98  \t\t<dependency>\n 99  \t\t\t<groupId>org.hibernate</groupId>\n100  \t\t\t<artifactId>hibernate-entitymanager</artifactId>\n101  \t\t\t<version>${hibernate.version}</version>\n102  \t\t</dependency>\n103  \t\t<dependency>\n104  \t\t\t<groupId>org.hibernate.validator</groupId>\n105  \t\t\t<artifactId>hibernate-validator</artifactId>\n106  \t\t\t<version>${hibernate-validator.version}</version>\n107  \t\t</dependency>\n108  \t\t<dependency>\n109  \t\t\t<groupId>ch.qos.logback</groupId>\n110  \t\t\t<artifactId>logback-classic</artifactId>"
+        lineNumber: 99
+        variables:
+          name: javax.activation.javax.activation-api
+          version: 1.2.0
+      links:
+      - url: https://jakarta.ee/
+        title: Jakarta EE
+      effort: 1
+    jboss-dependencies-00027:
+      description: Replace org.hibernate group with org.hibernate.orm
+      category: mandatory
+      labels:
+      - konveyor.io/source=jakarta-ee
+      - konveyor.io/source=jakarta-ee7+
+      - konveyor.io/target=eap
+      - konveyor.io/target=eap8
+      incidents:
+      - uri: file:///shared/source/tackle-testapp/pom.xml
+        message: "Update the dependency by replacing the group `org.hibernate` artifact `hibernate-core` \n with group `org.hibernate.orm` artifact `hibernate-core`"
+        codeSnip: " 90  \t\t\t<version>2.5.0</version>\n 91  \t\t</dependency>\n 92  \t\t<dependency>\n 93  \t\t\t<groupId>org.apache.tomcat</groupId>\n 94  \t\t\t<artifactId>tomcat-jdbc</artifactId>\n 95  \t\t\t<version>${tomcat.version}</version>\n 96  \t\t\t<scope>runtime</scope>\n 97  \t\t</dependency>\n 98  \t\t<dependency>\n 99  \t\t\t<groupId>org.hibernate</groupId>\n100  \t\t\t<artifactId>hibernate-entitymanager</artifactId>\n101  \t\t\t<version>${hibernate.version}</version>\n102  \t\t</dependency>\n103  \t\t<dependency>\n104  \t\t\t<groupId>org.hibernate.validator</groupId>\n105  \t\t\t<artifactId>hibernate-validator</artifactId>\n106  \t\t\t<version>${hibernate-validator.version}</version>\n107  \t\t</dependency>\n108  \t\t<dependency>\n109  \t\t\t<groupId>ch.qos.logback</groupId>\n110  \t\t\t<artifactId>logback-classic</artifactId>"
+        lineNumber: 99
+        variables:
+          name: org.hibernate.hibernate-core
+          version: 5.4.32.Final
+      links:
+      - url: https://access.redhat.com/articles/6980017
+        title: Migrating a JBoss EAP Application's Maven Project to EAP 8
+      effort: 1
+  errors:
+    eap8-xml-binding-00001: unable to ask for Konveyor rule entry
+    hibernate-00005: connection to the language server is closed, language server is not running
+    hibernate-6.2-00040: unable to ask for Konveyor rule entry
+    hibernate-6.2-00050: unable to ask for Konveyor rule entry
+    hibernate-00010: connection to the language server is closed, language server is not running
+    hibernate-search-00010: unable to ask for Konveyor rule entry
+    hibernate-search-00630: unable to ask for Konveyor rule entry
+    hibernate-search-00640: connection to the language server is closed, language server is not running
+    hibernate-search-00650: connection to the language server is closed, language server is not running
+    hibernate-search-00660: connection to the language server is closed, language server is not running
+    hibernate-search-00670: connection to the language server is closed, language server is not running
+    hibernate-search-00680: connection to the language server is closed, language server is not running
+    hibernate-search-00690: connection to the language server is closed, language server is not running
+    hibernate-search-00700: connection to the language server is closed, language server is not running
+    hibernate-search-00710: connection to the language server is closed, language server is not running
+    hibernate-search-00720: connection to the language server is closed, language server is not running
+    hibernate-search-00730: connection to the language server is closed, language server is not running
+    hibernate-search-00740: connection to the language server is closed, language server is not running
+    hibernate-search-00750: connection to the language server is closed, language server is not running
+    hibernate-search-00760: connection to the language server is closed, language server is not running
+    hibernate-search-00770: connection to the language server is closed, language server is not running
+    hibernate-search-00780: connection to the language server is closed, language server is not running
+    hibernate-search-00790: connection to the language server is closed, language server is not running
+    hibernate-search-00800: connection to the language server is closed, language server is not running
+    hibernate-search-00810: connection to the language server is closed, language server is not running
+    hibernate-search-00820: connection to the language server is closed, language server is not running
+    hibernate-search-00830: connection to the language server is closed, language server is not running
+    hibernate-search-00840: connection to the language server is closed, language server is not running
+    hibernate-search-00850: connection to the language server is closed, language server is not running
+    hibernate-search-00860: connection to the language server is closed, language server is not running
+    hibernate-search-00870: connection to the language server is closed, language server is not running
+    hibernate-search-00880: connection to the language server is closed, language server is not running
+    hibernate-search-00890: connection to the language server is closed, language server is not running
+    hibernate-search-00900: connection to the language server is closed, language server is not running
+    hibernate-search-00910: connection to the language server is closed, language server is not running
+    hibernate-search-00920: connection to the language server is closed, language server is not running
+    hibernate-search-00930: connection to the language server is closed, language server is not running
+    hibernate-search-00940: connection to the language server is closed, language server is not running
+    hibernate-search-00950: connection to the language server is closed, language server is not running
+    hibernate-search-00960: connection to the language server is closed, language server is not running
+    hibernate-search-00970: connection to the language server is closed, language server is not running
+    hibernate-search-00980: connection to the language server is closed, language server is not running
+    hibernate-search-00990: connection to the language server is closed, language server is not running
+    hibernate-search-01000: connection to the language server is closed, language server is not running
+    hibernate-search-01010: connection to the language server is closed, language server is not running
+    hibernate-search-01020: connection to the language server is closed, language server is not running
+    hibernate-search-01030: connection to the language server is closed, language server is not running
+    hibernate6-00020: connection to the language server is closed, language server is not running
+    hibernate6-00030: connection to the language server is closed, language server is not running
+    hibernate6-00040: connection to the language server is closed, language server is not running
+    hibernate6-00050: connection to the language server is closed, language server is not running
+    hibernate6-00060: connection to the language server is closed, language server is not running
+    hibernate6-00070: connection to the language server is closed, language server is not running
+    hibernate6-00090: connection to the language server is closed, language server is not running
+    hibernate6-00100: connection to the language server is closed, language server is not running
+    hibernate6-00110: connection to the language server is closed, language server is not running
+    hibernate6-00120: connection to the language server is closed, language server is not running
+    hibernate6-00130: connection to the language server is closed, language server is not running
+    hibernate6-00140: connection to the language server is closed, language server is not running
+    hibernate6-00150: connection to the language server is closed, language server is not running
+    hibernate6-00170: connection to the language server is closed, language server is not running
+    hibernate6-00180: connection to the language server is closed, language server is not running
+    hibernate6-00190: connection to the language server is closed, language server is not running
+    hibernate6-00210: connection to the language server is closed, language server is not running
+    hibernate6-00220: connection to the language server is closed, language server is not running
+    hibernate6-00280: connection to the language server is closed, language server is not running
+    jakarta-cdi-00001: connection to the language server is closed, language server is not running
+    jakarta-cdi-00002: connection to the language server is closed, language server is not running
+    jakarta-cdi-00003: connection to the language server is closed, language server is not running
+    jakarta-cdi-00004: connection to the language server is closed, language server is not running
+    jakarta-el-00010: connection to the language server is closed, language server is not running
+    jakarta-el-00020: connection to the language server is closed, language server is not running
+    jakarta-faces-00001: connection to the language server is closed, language server is not running
+    jakarta-json-binding-00010: connection to the language server is closed, language server is not running
+    jakarta-soap-00010: connection to the language server is closed, language server is not running
+    jakarta-soap-00020: connection to the language server is closed, language server is not running
+    jakarta-ws-rs-00001: connection to the language server is closed, language server is not running
+    javax-to-jakarta-import-00001: connection to the language server is closed, language server is not running
+    javax-to-jakarta-servlet-00010: connection to the language server is closed, language server is not running
+    javax-to-jakarta-servlet-00020: connection to the language server is closed, language server is not running
+    javax-to-jakarta-servlet-00030: connection to the language server is closed, language server is not running
+    javax-to-jakarta-servlet-00040: connection to the language server is closed, language server is not running
+    javax-to-jakarta-servlet-00041: connection to the language server is closed, language server is not running
+    javax-to-jakarta-servlet-00042: connection to the language server is closed, language server is not running
+    javax-to-jakarta-servlet-00043: connection to the language server is closed, language server is not running
+    javax-to-jakarta-servlet-00050: connection to the language server is closed, language server is not running
+    javax-to-jakarta-servlet-00060: connection to the language server is closed, language server is not running
+    javax-to-jakarta-servlet-00070: connection to the language server is closed, language server is not running
+    javax-to-jakarta-servlet-00071: connection to the language server is closed, language server is not running
+    javax-to-jakarta-servlet-00072: connection to the language server is closed, language server is not running
+    javax-to-jakarta-servlet-00080: connection to the language server is closed, language server is not running
+    javax-to-jakarta-servlet-00090: connection to the language server is closed, language server is not running
+    javax-to-jakarta-servlet-00100: connection to the language server is closed, language server is not running
+    javax-to-jakarta-servlet-00101: connection to the language server is closed, language server is not running
+    javax-to-jakarta-servlet-00102: connection to the language server is closed, language server is not running
+    javax-to-jakarta-servlet-00110: connection to the language server is closed, language server is not running
+    javax-to-jakarta-servlet-00111: connection to the language server is closed, language server is not running
+    javax-to-jakarta-servlet-00112: connection to the language server is closed, language server is not running
+    javax-to-jakarta-servlet-00120: connection to the language server is closed, language server is not running
+    javax-to-jakarta-servlet-00121: connection to the language server is closed, language server is not running
+    javax-to-jakarta-servlet-00122: connection to the language server is closed, language server is not running
+    javax-to-jakarta-servlet-00123: connection to the language server is closed, language server is not running
+    log4j-removed-00001: connection to the language server is closed, language server is not running
+    log4j-removed-00002: connection to the language server is closed, language server is not running
+    login-modules-00001: connection to the language server is closed, language server is not running
+  unmatched:
+  - deprecated-initialcontextfactory-is-removed-00001
+  - eap8-ejb-00001
+  - eap8-ejb-00002
+  - eap8-ejb-00003
+  - eap8-faces-00001
+  - eap8-faces-00002
+  - eap8-faces-00003
+  - eap8-faces-00004
+  - eap8-faces-00005
+  - eap8-faces-00006
+  - eap8-faces-00007
+  - eap8-faces-00008
+  - eap8-faces-00009
+  - eap8-resteasy-00001
+  - eap8-resteasy-00002
+  - eap8-resteasy-00003
+  - eap8-resteasy-00004
+  - eap8-resteasy-00005
+  - eap8-resteasy-00006
+  - eap8-resteasy-00007
+  - eap8-resteasy-00008
+  - eap8-resteasy-00009
+  - eap8-resteasy-00010
+  - eap8-resteasy-00011
+  - eap8-xml-binding-00002
+  - eap8-xml-binding-00003
+  - eap8-xml-binding-00004
+  - eap8-xml-binding-00005
+  - eap8-xml-binding-00006
+  - eap8-xml-binding-00007
+  - eap8-xml-binding-00009
+  - empty-beans-xml-00001
+  - hibernate-6.2-00010
+  - hibernate-6.2-00020
+  - hibernate-6.2-00030
+  - hibernate-search-00020
+  - hibernate-search-00030
+  - hibernate-search-00040
+  - hibernate-search-00050
+  - hibernate-search-00060
+  - hibernate-search-00070
+  - hibernate-search-00080
+  - hibernate-search-00090
+  - hibernate-search-00100
+  - hibernate-search-00105
+  - hibernate-search-00110
+  - hibernate-search-00120
+  - hibernate-search-00140
+  - hibernate-search-00150
+  - hibernate-search-00160
+  - hibernate-search-00170
+  - hibernate-search-00180
+  - hibernate-search-00190
+  - hibernate-search-00200
+  - hibernate-search-00210
+  - hibernate-search-00220
+  - hibernate-search-00230
+  - hibernate-search-00240
+  - hibernate-search-00250
+  - hibernate-search-00260
+  - hibernate-search-00270
+  - hibernate-search-00280
+  - hibernate-search-00290
+  - hibernate-search-00300
+  - hibernate-search-00310
+  - hibernate-search-00320
+  - hibernate-search-00330
+  - hibernate-search-00340
+  - hibernate-search-00350
+  - hibernate-search-00360
+  - hibernate-search-00370
+  - hibernate-search-00380
+  - hibernate-search-00390
+  - hibernate-search-00400
+  - hibernate-search-00410
+  - hibernate-search-00420
+  - hibernate-search-00430
+  - hibernate-search-00440
+  - hibernate-search-00450
+  - hibernate-search-00460
+  - hibernate-search-00470
+  - hibernate-search-00480
+  - hibernate-search-00490
+  - hibernate-search-00500
+  - hibernate-search-00510
+  - hibernate-search-00520
+  - hibernate-search-00530
+  - hibernate-search-00540
+  - hibernate-search-00550
+  - hibernate-search-00560
+  - hibernate-search-00570
+  - hibernate-search-00580
+  - hibernate-search-00590
+  - hibernate-search-00600
+  - hibernate-search-00610
+  - hibernate-search-00620
+  - hibernate-search-01040
+  - hibernate-search-6.1-00020
+  - hibernate-search-6.1-00030
+  - hibernate-search-6.1-00040
+  - hibernate-search-6.1-00050
+  - hibernate-search-6.1-00060
+  - hibernate-search-6.1-00070
+  - hibernate-search-6.1-00080
+  - hibernate-search-6.1-00090
+  - hibernate-search-6.1-00100
+  - hibernate-search-6.1-00120
+  - hibernate-search-6.1-00130
+  - hibernate-search-6.1-00140
+  - hibernate-search-6.1-00150
+  - hibernate-search-6.1-00160
+  - hibernate-search-6.1-00170
+  - hibernate-search-6.1-00180
+  - hibernate-search-6.1-00190
+  - hibernate6-00080
+  - hibernate6-00160
+  - hibernate6-00200
+  - hibernate6-00230
+  - hibernate6-00240
+  - hibernate6-00250
+  - hibernate6-00251
+  - hibernate6-00252
+  - hibernate6-00253
+  - hibernate6-00254
+  - hibernate6-00255
+  - hibernate6-00257
+  - hibernate6-00270
+  - javaee-to-jakarta-namespaces-00001
+  - javaee-to-jakarta-namespaces-00002
+  - javaee-to-jakarta-namespaces-00003
+  - javaee-to-jakarta-namespaces-00004
+  - javaee-to-jakarta-namespaces-00005
+  - javaee-to-jakarta-namespaces-00006
+  - javaee-to-jakarta-namespaces-00007
+  - javaee-to-jakarta-namespaces-00008
+  - javaee-to-jakarta-namespaces-00009
+  - javaee-to-jakarta-namespaces-00010
+  - javaee-to-jakarta-namespaces-00011
+  - javaee-to-jakarta-namespaces-00012
+  - javaee-to-jakarta-namespaces-00013
+  - javaee-to-jakarta-namespaces-00014
+  - javaee-to-jakarta-namespaces-00015
+  - javaee-to-jakarta-namespaces-00016
+  - javaee-to-jakarta-namespaces-00017
+  - javaee-to-jakarta-namespaces-00018
+  - javaee-to-jakarta-namespaces-00019
+  - javaee-to-jakarta-namespaces-00020
+  - javaee-to-jakarta-namespaces-00021
+  - javaee-to-jakarta-namespaces-00022
+  - javaee-to-jakarta-namespaces-00023
+  - javaee-to-jakarta-namespaces-00024
+  - javaee-to-jakarta-namespaces-00025
+  - javaee-to-jakarta-namespaces-00026
+  - javaee-to-jakarta-namespaces-00027
+  - javaee-to-jakarta-namespaces-00028
+  - javaee-to-jakarta-namespaces-00029
+  - javaee-to-jakarta-namespaces-00030
+  - javaee-to-jakarta-namespaces-00031
+  - javaee-to-jakarta-namespaces-00032
+  - javaee-to-jakarta-namespaces-00033
+  - javaee-to-jakarta-namespaces-00034
+  - javaee-to-jakarta-namespaces-00035
+  - javaee-to-jakarta-namespaces-00036
+  - javaee-to-jakarta-namespaces-00037
+  - javaee-to-jakarta-namespaces-00038
+  - javaee-to-jakarta-namespaces-00039
+  - javaee-to-jakarta-namespaces-00040
+  - javaee-to-jakarta-namespaces-00041
+  - javaee-to-jakarta-namespaces-00042
+  - javaee-to-jakarta-namespaces-00043
+  - javaee-to-jakarta-namespaces-00044
+  - javaee-to-jakarta-namespaces-00045
+  - javaee-to-jakarta-namespaces-00046
+  - javaee-to-jakarta-namespaces-00047
+  - javaee-to-jakarta-namespaces-00048
+  - javaee-to-jakarta-namespaces-00049
+  - javaee-to-jakarta-namespaces-00050
+  - javaee-to-jakarta-namespaces-00051
+  - javaee-to-jakarta-namespaces-00052
+  - javaee-to-jakarta-namespaces-00053
+  - javaee-to-jakarta-namespaces-00054
+  - javaee-to-jakarta-namespaces-00055
+  - javaee-to-jakarta-namespaces-00056
+  - javax-to-jakarta-bootstrapping-files-00001
+  - javax-to-jakarta-dependencies-00001
+  - javax-to-jakarta-dependencies-00002
+  - javax-to-jakarta-dependencies-00003
+  - javax-to-jakarta-dependencies-00005
+  - javax-to-jakarta-dependencies-00006
+  - javax-to-jakarta-dependencies-00007
+  - javax-to-jakarta-dependencies-00008
+  - javax-to-jakarta-properties-00001
+  - javax-to-jakarta-servlet-00130
+  - jboss-dependencies-00001
+  - jboss-dependencies-00002
+  - jboss-dependencies-00003
+  - jboss-dependencies-00004
+  - jboss-dependencies-00005
+  - jboss-dependencies-00006
+  - jboss-dependencies-00007
+  - jboss-dependencies-00008
+  - jboss-dependencies-00009
+  - jboss-dependencies-00010
+  - jboss-dependencies-00011
+  - jboss-dependencies-00012
+  - jboss-dependencies-00013
+  - jboss-dependencies-00014
+  - jboss-dependencies-00015
+  - jboss-dependencies-00016
+  - jboss-dependencies-00017
+  - jboss-dependencies-00018
+  - jboss-dependencies-00019
+  - jboss-dependencies-00020
+  - jboss-dependencies-00021
+  - jboss-dependencies-00022
+  - jboss-dependencies-00023
+  - jboss-dependencies-00024
+  - jboss-dependencies-00025
+  - jboss-dependencies-00026
+  - jboss-dependencies-00028
+  - jboss-dependencies-00030
+  - jboss-dependencies-00031
+  - jboss-dependencies-00032
+  - keycloak-openid-00001
+  - keycloak-openid-00010
+  - legacy-vault-00010
+  - log4j-removed-00003
+  - log4j-removed-00004
+  - log4j-removed-00005
+  - picketlink-00010
+  - picketlink-00020
+- name: hibernate
+  description: This ruleset provides analysis of deprecated Hibernate java constructs and their migration to newer one.
+  skipped:
+  - hibernate-01000
+  - hibernate-02000
+  - hibernate-03000
+  - hibernate-04000
+  - hibernate-05000
+  - hibernate-06000
+  - hibernate-07000
+  - hibernate-08000
+  - hibernate-09000
+  - hibernate-10000
+  - hibernate-10100
+  - hibernate-catchall-00000
+  - hibernate-xml-01000
+  - hibernate-xml-02000
+  - hibernate-xml-03000
+  - hibernate-xml-04000
+  - hibernate-xml-05000
+- name: technology-usage
+  description: This ruleset provides analysis of logging libraries.
+  tags:
+  - Bean=EJB XML
+  - Connect=EJB XML
+  - Connect=Servlet
+  - Embedded Spring Data JPA
+  - Embedded framework - Micrometer
+  - Embedded framework - Spring DI
+  - Embedded framework - Spring MVC
+  - Embedded framework - Spring Web
+  - Embedded library - Spring Boot Actuator
+  - Embedded=Micrometer
+  - Embedded=Properties
+  - Embedded=Spring DI
+  - Embedded=Spring Data JPA
+  - Embedded=Spring Web
+  - Execute=Micrometer
+  - Execute=Spring DI
+  - HTTP=Servlet
+  - Integration=Micrometer
+  - Inversion of Control=Spring DI
+  - Java EE=EJB XML
+  - Java EE=JPA named queries
+  - Java EE=Servlet
+  - Java Servlet
+  - Micrometer
+  - Other=Properties
+  - Persistence=JPA named queries
+  - Persistence=Spring Data JPA
+  - Servlet
+  - Spring Boot Actuator
+  - Spring DI
+  - Spring Data JPA
+  - Spring MVC
+  - Spring Web
+  - Store=JPA named queries
+  - Store=Spring Data JPA
+  - Sustain=Properties
+  - View=Spring Web
+  - Web=Spring Web
+  insights:
+    database-03000:
+      description: Embedded Spring Data JPA
+      labels:
+      - discovery
+      - konveyor.io/include=always
+      - tag=Embedded Spring Data JPA
+      - tag=Spring Data JPA
+      incidents:
+      - uri: file:///shared/source/tackle-testapp/pom.xml
+        message: ""
+        codeSnip: "59  \t\t<dependency>\n60  \t\t\t<groupId>com.fasterxml.jackson.core</groupId>\n61  \t\t\t<artifactId>jackson-core</artifactId>\n62  \t\t</dependency>\n63  \t\t<dependency>\n64  \t\t\t<groupId>com.fasterxml.jackson.core</groupId>\n65  \t\t\t<artifactId>jackson-databind</artifactId>\n66  \t\t</dependency>\n67  \t\t<dependency>\n68  \t\t\t<groupId>org.springframework.data</groupId>\n69  \t\t\t<artifactId>spring-data-jpa</artifactId>\n70  \t\t</dependency>\n71  \n72  \t\t<dependency>\n73  \t\t\t<groupId>org.springframework</groupId>\n74  \t\t\t<artifactId>spring-jdbc</artifactId>\n75  \t\t\t<version>${spring-framework.version}</version>\n76  \t\t</dependency>\n77  \t\t<dependency>\n78  \t\t\t<groupId>org.springframework</groupId>\n79  \t\t\t<artifactId>spring-webmvc</artifactId>"
+        lineNumber: 68
+        variables:
+          name: org.springframework.data.spring-data-jpa
+          version: 2.5.1
+    embedded-framework-08200:
+      description: Embedded framework - Spring DI
+      labels:
+      - discovery
+      - konveyor.io/include=always
+      - tag=Embedded framework - Spring DI
+      - tag=Spring DI
+      incidents:
+      - uri: file:///shared/source/tackle-testapp/pom.xml
+        message: ""
+        codeSnip: "59  \t\t<dependency>\n60  \t\t\t<groupId>com.fasterxml.jackson.core</groupId>\n61  \t\t\t<artifactId>jackson-core</artifactId>\n62  \t\t</dependency>\n63  \t\t<dependency>\n64  \t\t\t<groupId>com.fasterxml.jackson.core</groupId>\n65  \t\t\t<artifactId>jackson-databind</artifactId>\n66  \t\t</dependency>\n67  \t\t<dependency>\n68  \t\t\t<groupId>org.springframework.data</groupId>\n69  \t\t\t<artifactId>spring-data-jpa</artifactId>\n70  \t\t</dependency>\n71  \n72  \t\t<dependency>\n73  \t\t\t<groupId>org.springframework</groupId>\n74  \t\t\t<artifactId>spring-jdbc</artifactId>\n75  \t\t\t<version>${spring-framework.version}</version>\n76  \t\t</dependency>\n77  \t\t<dependency>\n78  \t\t\t<groupId>org.springframework</groupId>\n79  \t\t\t<artifactId>spring-webmvc</artifactId>"
+        lineNumber: 68
+        variables:
+          name: org.springframework.spring-beans
+          version: 5.3.7
+    embedded-framework-08300:
+      description: Embedded framework - Micrometer
+      labels:
+      - discovery
+      - konveyor.io/include=always
+      - tag=Embedded framework - Micrometer
+      - tag=Micrometer
+      incidents:
+      - uri: file:///shared/source/tackle-testapp/pom.xml
+        message: ""
+        codeSnip: "79  \t\t\t<artifactId>spring-webmvc</artifactId>\n80  \t\t\t<version>${spring-framework.version}</version>\n81  \t\t</dependency>\n82  \t\t<dependency>\n83  \t\t\t<groupId>org.springframework</groupId>\n84  \t\t\t<artifactId>spring-web</artifactId>\n85  \t\t\t<version>${spring-framework.version}</version>\n86  \t\t</dependency>\n87  \t\t<dependency>\n88  \t\t\t<groupId>org.springframework.boot</groupId>\n89  \t\t\t<artifactId>spring-boot-starter-actuator</artifactId>\n90  \t\t\t<version>2.5.0</version>\n91  \t\t</dependency>\n92  \t\t<dependency>\n93  \t\t\t<groupId>org.apache.tomcat</groupId>\n94  \t\t\t<artifactId>tomcat-jdbc</artifactId>\n95  \t\t\t<version>${tomcat.version}</version>\n96  \t\t\t<scope>runtime</scope>\n97  \t\t</dependency>\n98  \t\t<dependency>\n99  \t\t\t<groupId>org.hibernate</groupId>"
+        lineNumber: 88
+        variables:
+          name: io.micrometer.micrometer-core
+          version: 1.7.0
+    embedded-framework-08400:
+      description: Embedded framework - Spring Web
+      labels:
+      - discovery
+      - konveyor.io/include=always
+      - tag=Embedded framework - Spring Web
+      - tag=Spring Web
+      incidents:
+      - uri: file:///shared/source/tackle-testapp/pom.xml
+        message: ""
+        codeSnip: "74  \t\t\t<artifactId>spring-jdbc</artifactId>\n75  \t\t\t<version>${spring-framework.version}</version>\n76  \t\t</dependency>\n77  \t\t<dependency>\n78  \t\t\t<groupId>org.springframework</groupId>\n79  \t\t\t<artifactId>spring-webmvc</artifactId>\n80  \t\t\t<version>${spring-framework.version}</version>\n81  \t\t</dependency>\n82  \t\t<dependency>\n83  \t\t\t<groupId>org.springframework</groupId>\n84  \t\t\t<artifactId>spring-web</artifactId>\n85  \t\t\t<version>${spring-framework.version}</version>\n86  \t\t</dependency>\n87  \t\t<dependency>\n88  \t\t\t<groupId>org.springframework.boot</groupId>\n89  \t\t\t<artifactId>spring-boot-starter-actuator</artifactId>\n90  \t\t\t<version>2.5.0</version>\n91  \t\t</dependency>\n92  \t\t<dependency>\n93  \t\t\t<groupId>org.apache.tomcat</groupId>\n94  \t\t\t<artifactId>tomcat-jdbc</artifactId>"
+        lineNumber: 83
+        variables:
+          name: org.springframework.spring-web
+          version: 5.3.7
+    javaee-technology-usage-00120:
+      description: Java Servlet
+      labels:
+      - discovery
+      - konveyor.io/include=always
+      - tag=Java Servlet
+      - tag=Servlet
+      incidents:
+      - uri: file:///shared/source/tackle-testapp/src/main/java/io/konveyor/demo/ordermanagement/OrderManagementAppInitializer.java
+        message: ""
+        codeSnip: " 1  package io.konveyor.demo.ordermanagement;\n 2  \n 3  import javax.servlet.ServletContext;\n 4  import javax.servlet.ServletException;\n 5  import javax.servlet.ServletRegistration;\n 6  \n 7  import org.springframework.web.WebApplicationInitializer;\n 8  import org.springframework.web.context.ContextLoaderListener;\n 9  import org.springframework.web.context.support.AnnotationConfigWebApplicationContext;\n10  import org.springframework.web.servlet.DispatcherServlet;\n11  \n12  public class OrderManagementAppInitializer implements WebApplicationInitializer  {\n13  "
+        lineNumber: 3
+        variables:
+          file: file:///shared/source/tackle-testapp/src/main/java/io/konveyor/demo/ordermanagement/OrderManagementAppInitializer.java
+          kind: Module
+          name: javax.servlet.ServletContext
+          package: io.konveyor.demo.ordermanagement
+      - uri: file:///shared/source/tackle-testapp/src/main/java/io/konveyor/demo/ordermanagement/OrderManagementAppInitializer.java
+        message: ""
+        codeSnip: " 1  package io.konveyor.demo.ordermanagement;\n 2  \n 3  import javax.servlet.ServletContext;\n 4  import javax.servlet.ServletException;\n 5  import javax.servlet.ServletRegistration;\n 6  \n 7  import org.springframework.web.WebApplicationInitializer;\n 8  import org.springframework.web.context.ContextLoaderListener;\n 9  import org.springframework.web.context.support.AnnotationConfigWebApplicationContext;\n10  import org.springframework.web.servlet.DispatcherServlet;\n11  \n12  public class OrderManagementAppInitializer implements WebApplicationInitializer  {\n13  \n14  \t@Override"
+        lineNumber: 4
+        variables:
+          file: file:///shared/source/tackle-testapp/src/main/java/io/konveyor/demo/ordermanagement/OrderManagementAppInitializer.java
+          kind: Module
+          name: javax.servlet.ServletException
+          package: io.konveyor.demo.ordermanagement
+      - uri: file:///shared/source/tackle-testapp/src/main/java/io/konveyor/demo/ordermanagement/OrderManagementAppInitializer.java
+        message: ""
+        codeSnip: " 1  package io.konveyor.demo.ordermanagement;\n 2  \n 3  import javax.servlet.ServletContext;\n 4  import javax.servlet.ServletException;\n 5  import javax.servlet.ServletRegistration;\n 6  \n 7  import org.springframework.web.WebApplicationInitializer;\n 8  import org.springframework.web.context.ContextLoaderListener;\n 9  import org.springframework.web.context.support.AnnotationConfigWebApplicationContext;\n10  import org.springframework.web.servlet.DispatcherServlet;\n11  \n12  public class OrderManagementAppInitializer implements WebApplicationInitializer  {\n13  \n14  \t@Override\n15  \tpublic void onStartup(ServletContext container) throws ServletException {"
+        lineNumber: 5
+        variables:
+          file: file:///shared/source/tackle-testapp/src/main/java/io/konveyor/demo/ordermanagement/OrderManagementAppInitializer.java
+          kind: Module
+          name: javax.servlet.ServletRegistration
+          package: io.konveyor.demo.ordermanagement
+    javaee-technology-usage-00230:
+      description: ""
+      labels:
+      - discovery
+      - konveyor.io/include=always
+      - tag=Connect=Servlet
+      - tag=HTTP=Servlet
+      - tag=Java EE=Servlet
+      incidents:
+      - uri: ""
+        message: ""
+        variables:
+          tags:
+          - Servlet
+    mvc-01220:
+      description: Embedded framework - Spring MVC
+      labels:
+      - discovery
+      - konveyor.io/include=always
+      - tag=Embedded framework - Spring MVC
+      - tag=Spring MVC
+      incidents:
+      - uri: file:///shared/source/tackle-testapp/pom.xml
+        message: ""
+        codeSnip: "69  \t\t\t<artifactId>spring-data-jpa</artifactId>\n70  \t\t</dependency>\n71  \n72  \t\t<dependency>\n73  \t\t\t<groupId>org.springframework</groupId>\n74  \t\t\t<artifactId>spring-jdbc</artifactId>\n75  \t\t\t<version>${spring-framework.version}</version>\n76  \t\t</dependency>\n77  \t\t<dependency>\n78  \t\t\t<groupId>org.springframework</groupId>\n79  \t\t\t<artifactId>spring-webmvc</artifactId>\n80  \t\t\t<version>${spring-framework.version}</version>\n81  \t\t</dependency>\n82  \t\t<dependency>\n83  \t\t\t<groupId>org.springframework</groupId>\n84  \t\t\t<artifactId>spring-web</artifactId>\n85  \t\t\t<version>${spring-framework.version}</version>\n86  \t\t</dependency>\n87  \t\t<dependency>\n88  \t\t\t<groupId>org.springframework.boot</groupId>\n89  \t\t\t<artifactId>spring-boot-starter-actuator</artifactId>"
+        lineNumber: 78
+        variables:
+          name: org.springframework.spring-webmvc
+          version: 5.3.7
+    non-xml-technology-usage-02000:
+      description: ""
+      labels:
+      - discovery
+      - konveyor.io/include=always
+      - tag=Bean=EJB XML
+      - tag=Connect=EJB XML
+      - tag=Java EE=EJB XML
+      incidents:
+      - uri: ""
+        message: ""
+        variables:
+          tags:
+          - EJB XML
+    non-xml-technology-usage-20000:
+      description: ""
+      labels:
+      - discovery
+      - konveyor.io/include=always
+      - tag=Embedded=Properties
+      - tag=Other=Properties
+      - tag=Sustain=Properties
+      incidents:
+      - uri: ""
+        message: ""
+        variables:
+          tags:
+          - Properties
+    observability-0100:
+      description: Embedded library - Spring Boot Actuator
+      labels:
+      - discovery
+      - konveyor.io/include=always
+      - tag=Embedded library - Spring Boot Actuator
+      - tag=Spring Boot Actuator
+      incidents:
+      - uri: file:///shared/source/tackle-testapp/pom.xml
+        message: ""
+        codeSnip: "79  \t\t\t<artifactId>spring-webmvc</artifactId>\n80  \t\t\t<version>${spring-framework.version}</version>\n81  \t\t</dependency>\n82  \t\t<dependency>\n83  \t\t\t<groupId>org.springframework</groupId>\n84  \t\t\t<artifactId>spring-web</artifactId>\n85  \t\t\t<version>${spring-framework.version}</version>\n86  \t\t</dependency>\n87  \t\t<dependency>\n88  \t\t\t<groupId>org.springframework.boot</groupId>\n89  \t\t\t<artifactId>spring-boot-starter-actuator</artifactId>\n90  \t\t\t<version>2.5.0</version>\n91  \t\t</dependency>\n92  \t\t<dependency>\n93  \t\t\t<groupId>org.apache.tomcat</groupId>\n94  \t\t\t<artifactId>tomcat-jdbc</artifactId>\n95  \t\t\t<version>${tomcat.version}</version>\n96  \t\t\t<scope>runtime</scope>\n97  \t\t</dependency>\n98  \t\t<dependency>\n99  \t\t\t<groupId>org.hibernate</groupId>"
+        lineNumber: 88
+        variables:
+          name: org.springframework.boot.spring-boot-starter-actuator
+          version: 2.5.0
+    technology-usage-database-01200:
+      description: ""
+      labels:
+      - discovery
+      - konveyor.io/include=always
+      - tag=Java EE=JPA named queries
+      - tag=Persistence=JPA named queries
+      - tag=Store=JPA named queries
+      incidents:
+      - uri: file:///shared/source/tackle-testapp/src/main/java/io/konveyor/demo/ordermanagement/model/Customer.java
+        message: ""
+        codeSnip: " 1  package io.konveyor.demo.ordermanagement.model;\n 2  \n 3  import javax.persistence.Column;\n 4  import javax.persistence.Entity;\n 5  import javax.persistence.GeneratedValue;\n 6  import javax.persistence.GenerationType;\n 7  import javax.persistence.Id;\n 8  import javax.persistence.SequenceGenerator;\n 9  import javax.persistence.Table;\n10  \n11  @Entity\n12  @Table(name = \"customers\")\n13  public class Customer {\n14  \t@Id\n15      @SequenceGenerator(\n16              name = \"customersSequence\",\n17              sequenceName = \"customers_id_seq\",\n18              allocationSize = 1,\n19              initialValue = 6)\n20      @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = \"customersSequence\")\n21  \tprivate Long id;"
+        lineNumber: 11
+        variables:
+          file: file:///shared/source/tackle-testapp/src/main/java/io/konveyor/demo/ordermanagement/model/Customer.java
+          kind: Class
+          name: Entity
+          package: io.konveyor.demo.ordermanagement.model
+      - uri: file:///shared/source/tackle-testapp/src/main/java/io/konveyor/demo/ordermanagement/model/Customer.java
+        message: ""
+        codeSnip: " 2  \n 3  import javax.persistence.Column;\n 4  import javax.persistence.Entity;\n 5  import javax.persistence.GeneratedValue;\n 6  import javax.persistence.GenerationType;\n 7  import javax.persistence.Id;\n 8  import javax.persistence.SequenceGenerator;\n 9  import javax.persistence.Table;\n10  \n11  @Entity\n12  @Table(name = \"customers\")\n13  public class Customer {\n14  \t@Id\n15      @SequenceGenerator(\n16              name = \"customersSequence\",\n17              sequenceName = \"customers_id_seq\",\n18              allocationSize = 1,\n19              initialValue = 6)\n20      @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = \"customersSequence\")\n21  \tprivate Long id;\n22  \t"
+        lineNumber: 12
+        variables:
+          file: file:///shared/source/tackle-testapp/src/main/java/io/konveyor/demo/ordermanagement/model/Customer.java
+          kind: Class
+          name: Entity
+          package: io.konveyor.demo.ordermanagement.model
+    technology-usage-database-03100:
+      description: ""
+      labels:
+      - discovery
+      - konveyor.io/include=always
+      - tag=Embedded=Spring Data JPA
+      - tag=Persistence=Spring Data JPA
+      - tag=Store=Spring Data JPA
+      incidents:
+      - uri: ""
+        message: ""
+        variables:
+          tags:
+          - Spring Data JPA
+    technology-usage-embedded-framework-08200:
+      description: ""
+      labels:
+      - discovery
+      - konveyor.io/include=always
+      - tag=Embedded=Spring DI
+      - tag=Execute=Spring DI
+      - tag=Inversion of Control=Spring DI
+      incidents:
+      - uri: ""
+        message: ""
+        variables:
+          tags:
+          - Spring DI
+    technology-usage-embedded-framework-08300:
+      description: ""
+      labels:
+      - discovery
+      - konveyor.io/include=always
+      - tag=Embedded=Micrometer
+      - tag=Execute=Micrometer
+      - tag=Integration=Micrometer
+      incidents:
+      - uri: ""
+        message: ""
+        variables:
+          tags:
+          - Micrometer
+    technology-usage-embedded-framework-08400:
+      description: ""
+      labels:
+      - discovery
+      - konveyor.io/include=always
+      - tag=Embedded=Spring Web
+      - tag=View=Spring Web
+      - tag=Web=Spring Web
+      incidents:
+      - uri: ""
+        message: ""
+        variables:
+          tags:
+          - Spring Web
+  unmatched:
+  - 3rd-party-01000
+  - 3rd-party-02000
+  - 3rd-party-03000
+  - 3rd-party-04000
+  - 3rd-party-05000
+  - 3rd-party-06000
+  - 3rd-party-07000
+  - 3rd-party-08000
+  - 3rd-party-09000
+  - 3rd-party-10000
+  - 3rd-party-11000
+  - 3rd-party-12000
+  - 3rd-party-13000
+  - 3rd-party-14000
+  - 3rd-party-15000
+  - 3rd-party-16000
+  - 3rd-party-17000
+  - 3rd-party-18000
+  - 3rd-party-19000
+  - 3rd-party-spring-03001
+  - 3rd-party-spring-03002
+  - apm-00000
+  - apm-00001
+  - apm-00002
+  - apm-00003
+  - clustering-00000
+  - clustering-00001
+  - configuration-management-0100
+  - configuration-management-0200
+  - configuration-management-0300
+  - configuration-management-0400
+  - configuration-management-0500
+  - configuration-management-technology-usage-0100
+  - configuration-management-technology-usage-0200
+  - configuration-management-technology-usage-0300
+  - connect-01400
+  - connect-01500
+  - connect-01600
+  - connect-01700
+  - connect-01800
+  - connect-01900
+  - connect-02000
+  - connect-02100
+  - connect-02200
+  - connect-02300
+  - connect-02400
+  - connect-02500
+  - connect-02600
+  - connect-02700
+  - connect-02800
+  - connect-02900
+  - database-01400
+  - database-01400
+  - database-01500
+  - database-01600
+  - database-01700
+  - database-01800
+  - database-01805
+  - database-01900
+  - database-02000
+  - database-02100
+  - database-02200
+  - database-02300
+  - database-02400
+  - database-02500
+  - database-02600
+  - database-02700
+  - database-02800
+  - database-02900
+  - database-03100
+  - ejb-01000
+  - embedded-cache-libraries-01000
+  - embedded-cache-libraries-02000
+  - embedded-cache-libraries-03000
+  - embedded-cache-libraries-04000
+  - embedded-cache-libraries-05000
+  - embedded-cache-libraries-06000
+  - embedded-cache-libraries-07000
+  - embedded-cache-libraries-08000
+  - embedded-cache-libraries-09000
+  - embedded-cache-libraries-10000
+  - embedded-cache-libraries-11000
+  - embedded-cache-libraries-12000
+  - embedded-cache-libraries-13000
+  - embedded-cache-libraries-14000
+  - embedded-cache-libraries-15000
+  - embedded-cache-libraries-16000
+  - embedded-framework-01000
+  - embedded-framework-01010
+  - embedded-framework-01100
+  - embedded-framework-01200
+  - embedded-framework-01300
+  - embedded-framework-01400
+  - embedded-framework-01500
+  - embedded-framework-01600
+  - embedded-framework-01700
+  - embedded-framework-02000
+  - embedded-framework-02200
+  - embedded-framework-02300
+  - embedded-framework-02400
+  - embedded-framework-03000
+  - embedded-framework-03100
+  - embedded-framework-03200
+  - embedded-framework-03300
+  - embedded-framework-03400
+  - embedded-framework-04700
+  - embedded-framework-05000
+  - embedded-framework-05100
+  - embedded-framework-05300
+  - embedded-framework-05400
+  - embedded-framework-05500
+  - embedded-framework-05600
+  - embedded-framework-05700
+  - embedded-framework-05800
+  - embedded-framework-05900
+  - embedded-framework-06000
+  - embedded-framework-06100
+  - embedded-framework-06200
+  - embedded-framework-06300
+  - embedded-framework-06400
+  - embedded-framework-06500
+  - embedded-framework-06600
+  - embedded-framework-06700
+  - embedded-framework-06800
+  - embedded-framework-06900
+  - embedded-framework-07000
+  - embedded-framework-07100
+  - embedded-framework-07200
+  - embedded-framework-07300
+  - embedded-framework-07400
+  - embedded-framework-07500
+  - embedded-framework-07600
+  - embedded-framework-07700
+  - embedded-framework-07800
+  - embedded-framework-07900
+  - embedded-framework-08000
+  - embedded-framework-08100
+  - embedded-framework-08500
+  - embedded-framework-08600
+  - embedded-framework-08700
+  - embedded-framework-08800
+  - embedded-framework-08900
+  - embedded-framework-09000
+  - embedded-framework-09100
+  - embedded-framework-09300
+  - embedded-framework-embedded-framework-02700
+  - embedded-framework-embedded-framework-02800
+  - embedded-framework-embedded-framework-02900
+  - embedded-framework-embedded-framework-03000
+  - embedded-framework-embedded-framework-03100
+  - embedded-framework-embedded-framework-03200
+  - embedded-framework-embedded-framework-03300
+  - embedded-framework-embedded-framework-03400
+  - embedded-framework-embedded-framework-03500
+  - embedded-framework-embedded-framework-03600
+  - embedded-framework-embedded-framework-03700
+  - embedded-framework-embedded-framework-03800
+  - embedded-framework-embedded-framework-03900
+  - embedded-framework-embedded-framework-04000
+  - embedded-framework-embedded-framework-04100
+  - embedded-framework-embedded-framework-04200
+  - embedded-framework-embedded-framework-04300
+  - embedded-framework-embedded-framework-04400
+  - embedded-framework-embedded-framework-04500
+  - embedded-framework-embedded-framework-04600
+  - embedded-framework-embedded-framework-09200
+  - embedded-framework-embedded-framework-09300
+  - integration-00001
+  - integration-00002
+  - integration-00003
+  - integration-00004
+  - integration-00005
+  - integration-00006
+  - integration-00007
+  - integration-00008
+  - integration-00009
+  - integration-00010
+  - integration-00011
+  - integration-00012
+  - integration-00013
+  - integration-00014
+  - integration-00015
+  - integration-00016
+  - integration-00017
+  - javaee-technology-usage-00010
+  - javaee-technology-usage-00011
+  - javaee-technology-usage-00012
+  - javaee-technology-usage-00013
+  - javaee-technology-usage-00020-jakarta
+  - javaee-technology-usage-00020-javax
+  - javaee-technology-usage-00021
+  - javaee-technology-usage-00030
+  - javaee-technology-usage-00031
+  - javaee-technology-usage-00040
+  - javaee-technology-usage-00050
+  - javaee-technology-usage-00060
+  - javaee-technology-usage-00070
+  - javaee-technology-usage-00080
+  - javaee-technology-usage-00090
+  - javaee-technology-usage-00100
+  - javaee-technology-usage-00110
+  - javaee-technology-usage-00130
+  - javaee-technology-usage-00140
+  - javaee-technology-usage-00150
+  - javaee-technology-usage-00160
+  - javaee-technology-usage-00170
+  - javaee-technology-usage-00180
+  - javaee-technology-usage-00190
+  - javaee-technology-usage-00200
+  - javaee-technology-usage-00210
+  - javaee-technology-usage-00220
+  - javaee-technology-usage-00902
+  - javaee-technology-usage-00903
+  - javaee-technology-usage-00905
+  - javaee-technology-usage-00906
+  - javaee-technology-usage-00910
+  - javaee-technology-usage-00911
+  - javaee-technology-usage-00912
+  - javaee-technology-usage-00913
+  - javaee-technology-usage-00914
+  - javaee-technology-usage-00915
+  - javaee-technology-usage-00916
+  - javaee-technology-usage-00917
+  - javaee-technology-usage-00918
+  - javaee-technology-usage-00926
+  - javaee-technology-usage-00927
+  - javaee-technology-usage-00928
+  - javaee-technology-usage-00930
+  - javaee-technology-usage-00931
+  - javaee-technology-usage-00932
+  - javaee-technology-usage-00950
+  - javaee-technology-usage-00951
+  - javaee-technology-usage-00952
+  - javaee-technology-usage-00953
+  - javaee-technology-usage-00954
+  - javaee-technology-usage-00955
+  - javaee-technology-usage-00956
+  - javaee-technology-usage-00957
+  - javaee-technology-usage-00958
+  - javase-01000
+  - javase-01100
+  - javase-technology-usage-01000
+  - jta-00020
+  - jta-00030
+  - jta-00040
+  - jta-00050
+  - jta-00060
+  - jta-00070
+  - jta-00080
+  - jta-00090
+  - jta-00100
+  - jta-00110
+  - jta-00120
+  - jta-00130
+  - jta-00140
+  - jta-00150
+  - jta-00160
+  - jta-00170
+  - jta-00180
+  - jta-00190
+  - jta-00200
+  - jta-00210
+  - logging-usage-00010
+  - logging-usage-00020
+  - logging-usage-00030
+  - logging-usage-00040
+  - logging-usage-00050
+  - logging-usage-00080
+  - logging-usage-00090
+  - logging-usage-00100
+  - logging-usage-00110
+  - logging-usage-00120
+  - logging-usage-00130
+  - logging-usage-00140
+  - logging-usage-00150
+  - logging-usage-00160
+  - logging-usage-00170
+  - logging-usage-00180
+  - logging-usage-00190
+  - logging-usage-00200
+  - logging-usage-00210
+  - logging-usage-00220
+  - logging-usage-00230
+  - logging-usage-00240
+  - logging-usage-00250
+  - logging-usage-00260
+  - logging-usage-00270
+  - logging-usage-00280
+  - logging-usage-00290
+  - mvc-01000
+  - mvc-01100
+  - mvc-01200
+  - mvc-01210
+  - mvc-01300
+  - mvc-01400
+  - mvc-01500
+  - mvc-01600
+  - mvc-01700
+  - mvc-01800
+  - mvc-01900
+  - mvc-02000
+  - mvc-02100
+  - mvc-02200
+  - mvc-02300
+  - mvc-02400
+  - mvc-02500
+  - mvc-02600
+  - mvc-02700
+  - mvc-02800
+  - mvc-02900
+  - mvc-03000
+  - mvc-03100
+  - mvc-03200
+  - mvc-03300
+  - mvc-03400
+  - mvc-03500
+  - mvc-03600
+  - mvc-03700
+  - mvc-03800
+  - mvc-03900
+  - mvc-04000
+  - mvc-04100
+  - mvc-04200
+  - mvc-04300
+  - mvc-04400
+  - mvc-04500
+  - mvc-04600
+  - mvc-04700
+  - mvc-04800
+  - mvc-04900
+  - mvc-05000
+  - mvc-05100
+  - mvc-05200
+  - mvc-05300
+  - mvc-05400
+  - mvc-05500
+  - mvc-05600
+  - mvc-05700
+  - mvc-05800
+  - mvc-05900
+  - mvc-06000
+  - non-xml-technology-usage-05000
+  - non-xml-technology-usage-06000
+  - non-xml-technology-usage-12000
+  - non-xml-technology-usage-13000
+  - non-xml-technology-usage-14000
+  - non-xml-technology-usage-17000
+  - non-xml-technology-usage-18000
+  - non-xml-technology-usage-19000
+  - non-xml-technology-usage-21000
+  - non-xml-technology-usage-22000
+  - non-xml-technology-usage-23000
+  - non-xml-technology-usage-24000
+  - non-xml-technology-usage-25000
+  - non-xml-technology-usage-26000
+  - non-xml-technology-usage-27000
+  - observability-0200
+  - observability-technology-usage-0100
+  - observability-technology-usage-0200
+  - security-01100
+  - security-01200
+  - security-01300
+  - security-01400
+  - security-01500
+  - security-01600
+  - security-01700
+  - security-01800
+  - security-01900
+  - security-02000
+  - security-02100
+  - security-02200
+  - security-02300
+  - security-02400
+  - security-02500
+  - security-02600
+  - security-02700
+  - security-02800
+  - security-02900
+  - security-03000
+  - security-03100
+  - security-03200
+  - security-03300
+  - security-03400
+  - security-03500
+  - security-03600
+  - spring-catchall-00001
+  - technology-usage-3rd-party-01000
+  - technology-usage-3rd-party-02000
+  - technology-usage-3rd-party-03000
+  - technology-usage-3rd-party-04000
+  - technology-usage-3rd-party-05000
+  - technology-usage-3rd-party-06000
+  - technology-usage-3rd-party-08000
+  - technology-usage-3rd-party-09000
+  - technology-usage-3rd-party-10000
+  - technology-usage-3rd-party-11000
+  - technology-usage-3rd-party-12000
+  - technology-usage-3rd-party-13000
+  - technology-usage-3rd-party-14000
+  - technology-usage-3rd-party-15000
+  - technology-usage-3rd-party-16000
+  - technology-usage-3rd-party-17000
+  - technology-usage-3rd-party-18000
+  - technology-usage-3rd-party-19000
+  - technology-usage-3rd-party-20000
+  - technology-usage-3rd-party-spring-03001-0
+  - technology-usage-3rd-party-spring-03001-1
+  - technology-usage-3rd-party-spring-03001-2
+  - technology-usage-3rd-party-spring-03002
+  - technology-usage-apm-00010
+  - technology-usage-apm-00020
+  - technology-usage-apm-00030
+  - technology-usage-apm-00040
+  - technology-usage-clustering-01000
+  - technology-usage-clustering-02000
+  - technology-usage-connect-01000
+  - technology-usage-connect-01100
+  - technology-usage-connect-01101
+  - technology-usage-connect-01200
+  - technology-usage-connect-01300
+  - technology-usage-connect-01400
+  - technology-usage-connect-01500
+  - technology-usage-connect-01600
+  - technology-usage-connect-01700
+  - technology-usage-connect-01800
+  - technology-usage-connect-01900
+  - technology-usage-connect-02000
+  - technology-usage-connect-02100
+  - technology-usage-connect-02200
+  - technology-usage-connect-02300
+  - technology-usage-connect-02400
+  - technology-usage-connect-02500
+  - technology-usage-connect-02600
+  - technology-usage-connect-02700
+  - technology-usage-connect-02800
+  - technology-usage-connect-02900
+  - technology-usage-database-01000
+  - technology-usage-database-01001
+  - technology-usage-database-01100
+  - technology-usage-database-01300
+  - technology-usage-database-01400
+  - technology-usage-database-01500
+  - technology-usage-database-01600
+  - technology-usage-database-01700
+  - technology-usage-database-01800
+  - technology-usage-database-01900
+  - technology-usage-database-02000
+  - technology-usage-database-02100
+  - technology-usage-database-02200
+  - technology-usage-database-02300
+  - technology-usage-database-02400
+  - technology-usage-database-02500
+  - technology-usage-database-02600
+  - technology-usage-database-02700
+  - technology-usage-database-02800
+  - technology-usage-database-02900
+  - technology-usage-database-03000
+  - technology-usage-database-03200
+  - technology-usage-ejb-01400
+  - technology-usage-embedded-framework-01000
+  - technology-usage-embedded-framework-01010
+  - technology-usage-embedded-framework-01100
+  - technology-usage-embedded-framework-01200
+  - technology-usage-embedded-framework-01300
+  - technology-usage-embedded-framework-01400
+  - technology-usage-embedded-framework-01500
+  - technology-usage-embedded-framework-01600
+  - technology-usage-embedded-framework-01700
+  - technology-usage-embedded-framework-02000
+  - technology-usage-embedded-framework-02100
+  - technology-usage-embedded-framework-02200
+  - technology-usage-embedded-framework-02300
+  - technology-usage-embedded-framework-02400
+  - technology-usage-embedded-framework-04700
+  - technology-usage-embedded-framework-05000
+  - technology-usage-embedded-framework-05100
+  - technology-usage-embedded-framework-05300
+  - technology-usage-embedded-framework-05400
+  - technology-usage-embedded-framework-05600
+  - technology-usage-embedded-framework-05700
+  - technology-usage-embedded-framework-05800
+  - technology-usage-embedded-framework-05900
+  - technology-usage-embedded-framework-06000
+  - technology-usage-embedded-framework-06100
+  - technology-usage-embedded-framework-06200
+  - technology-usage-embedded-framework-06300
+  - technology-usage-embedded-framework-06400
+  - technology-usage-embedded-framework-06500
+  - technology-usage-embedded-framework-06600
+  - technology-usage-embedded-framework-06700
+  - technology-usage-embedded-framework-06800
+  - technology-usage-embedded-framework-06900
+  - technology-usage-embedded-framework-07000
+  - technology-usage-embedded-framework-07100
+  - technology-usage-embedded-framework-07200
+  - technology-usage-embedded-framework-07300
+  - technology-usage-embedded-framework-07400
+  - technology-usage-embedded-framework-07500
+  - technology-usage-embedded-framework-07600
+  - technology-usage-embedded-framework-07700
+  - technology-usage-embedded-framework-07800
+  - technology-usage-embedded-framework-07900
+  - technology-usage-embedded-framework-08000
+  - technology-usage-embedded-framework-08100
+  - technology-usage-embedded-framework-08500
+  - technology-usage-embedded-framework-08600
+  - technology-usage-embedded-framework-08700
+  - technology-usage-embedded-framework-08800
+  - technology-usage-embedded-framework-08900
+  - technology-usage-embedded-framework-09000
+  - technology-usage-embedded-framework-09100
+  - technology-usage-integration-00001
+  - technology-usage-integration-00002
+  - technology-usage-integration-00003
+  - technology-usage-integration-00004
+  - technology-usage-integration-00005
+  - technology-usage-integration-00006
+  - technology-usage-integration-00007
+  - technology-usage-integration-00008
+  - technology-usage-integration-00009
+  - technology-usage-integration-00010
+  - technology-usage-integration-00011
+  - technology-usage-integration-00012
+  - technology-usage-integration-00013
+  - technology-usage-integration-00014
+  - technology-usage-integration-00015
+  - technology-usage-jta-00020
+  - technology-usage-jta-00030
+  - technology-usage-jta-00040
+  - technology-usage-jta-00050
+  - technology-usage-jta-00060
+  - technology-usage-jta-00070
+  - technology-usage-jta-00080
+  - technology-usage-jta-00090
+  - technology-usage-jta-00100
+  - technology-usage-jta-00110
+  - technology-usage-jta-00120
+  - technology-usage-jta-00130
+  - technology-usage-jta-00140
+  - technology-usage-jta-00150
+  - technology-usage-jta-00160
+  - technology-usage-jta-00170
+  - technology-usage-jta-00180
+  - technology-usage-jta-00190
+  - technology-usage-jta-00200
+  - technology-usage-jta-00210
+  - technology-usage-logging-00010
+  - technology-usage-logging-000100
+  - technology-usage-logging-000110
+  - technology-usage-logging-000120
+  - technology-usage-logging-000130
+  - technology-usage-logging-000140
+  - technology-usage-logging-000150
+  - technology-usage-logging-000160
+  - technology-usage-logging-000170
+  - technology-usage-logging-000180
+  - technology-usage-logging-000190
+  - technology-usage-logging-00020
+  - technology-usage-logging-000200
+  - technology-usage-logging-000210
+  - technology-usage-logging-000220
+  - technology-usage-logging-000230
+  - technology-usage-logging-000240
+  - technology-usage-logging-000250
+  - technology-usage-logging-000260
+  - technology-usage-logging-000270
+  - technology-usage-logging-000280
+  - technology-usage-logging-000290
+  - technology-usage-logging-00030
+  - technology-usage-logging-00040
+  - technology-usage-logging-00050
+  - technology-usage-logging-00060
+  - technology-usage-logging-00070
+  - technology-usage-logging-00080
+  - technology-usage-logging-00090
+  - technology-usage-markup-01300
+  - technology-usage-mvc-01000
+  - technology-usage-mvc-01100
+  - technology-usage-mvc-01200
+  - technology-usage-mvc-01300
+  - technology-usage-mvc-01400
+  - technology-usage-mvc-01500
+  - technology-usage-mvc-01600
+  - technology-usage-mvc-01700
+  - technology-usage-mvc-01800
+  - technology-usage-mvc-01900
+  - technology-usage-mvc-02000
+  - technology-usage-mvc-02100
+  - technology-usage-mvc-02200
+  - technology-usage-mvc-02300
+  - technology-usage-mvc-02400
+  - technology-usage-mvc-02500
+  - technology-usage-mvc-02600
+  - technology-usage-mvc-02700
+  - technology-usage-mvc-02800
+  - technology-usage-mvc-02900
+  - technology-usage-mvc-03000
+  - technology-usage-mvc-03100
+  - technology-usage-mvc-03200
+  - technology-usage-mvc-03300
+  - technology-usage-mvc-03400
+  - technology-usage-mvc-03500
+  - technology-usage-mvc-03600
+  - technology-usage-mvc-03700
+  - technology-usage-mvc-03800
+  - technology-usage-mvc-03900
+  - technology-usage-mvc-04000
+  - technology-usage-mvc-04100
+  - technology-usage-mvc-04300
+  - technology-usage-mvc-04400
+  - technology-usage-mvc-04500
+  - technology-usage-mvc-04600
+  - technology-usage-mvc-04700
+  - technology-usage-mvc-04800
+  - technology-usage-mvc-04900
+  - technology-usage-mvc-05000
+  - technology-usage-mvc-05100
+  - technology-usage-mvc-05200
+  - technology-usage-mvc-05300
+  - technology-usage-mvc-05400
+  - technology-usage-mvc-05500
+  - technology-usage-mvc-05600
+  - technology-usage-mvc-05700
+  - technology-usage-mvc-05800
+  - technology-usage-mvc-05900
+  - technology-usage-mvc-06000
+  - technology-usage-mvc-0x4200
+  - technology-usage-security-01000
+  - technology-usage-security-01100
+  - technology-usage-security-01200
+  - technology-usage-security-01300
+  - technology-usage-security-01400
+  - technology-usage-security-01500
+  - technology-usage-security-01600
+  - technology-usage-security-01700
+  - technology-usage-security-01800
+  - technology-usage-security-01900
+  - technology-usage-security-02000
+  - technology-usage-security-02100
+  - technology-usage-security-02200
+  - technology-usage-security-02300
+  - technology-usage-security-02400
+  - technology-usage-security-02500
+  - technology-usage-security-02600
+  - technology-usage-security-02700
+  - technology-usage-security-02800
+  - technology-usage-security-02900
+  - technology-usage-security-03000
+  - technology-usage-security-03100
+  - technology-usage-security-03200
+  - technology-usage-security-03300
+  - technology-usage-security-03400
+  - technology-usage-security-03500
+  - technology-usage-test-frameworks-00010
+  - technology-usage-test-frameworks-00020
+  - technology-usage-test-frameworks-00030
+  - technology-usage-test-frameworks-00040
+  - technology-usage-test-frameworks-00050
+  - technology-usage-test-frameworks-00060
+  - technology-usage-test-frameworks-00070
+  - technology-usage-test-frameworks-00080
+  - technology-usage-test-frameworks-00090
+  - technology-usage-test-frameworks-00100
+  - technology-usage-test-frameworks-00110
+  - technology-usage-test-frameworks-00120
+  - technology-usage-test-frameworks-00130
+  - technology-usage-test-frameworks-00140
+  - technology-usage-test-frameworks-00150
+  - technology-usage-test-frameworks-00160
+  - technology-usage-test-frameworks-00170
+  - technology-usage-test-frameworks-00180
+  - technology-usage-test-frameworks-00190
+  - technology-usage-test-frameworks-00200
+  - technology-usage-test-frameworks-00210
+  - technology-usage-test-frameworks-00220
+  - technology-usage-test-frameworks-00230
+  - technology-usage-test-frameworks-00240
+  - technology-usage-test-frameworks-00250
+  - technology-usage-test-frameworks-00260
+  - technology-usage-test-frameworks-00270
+  - technology-usage-test-frameworks-00280
+  - technology-usage-test-frameworks-00290
+  - technology-usage-test-frameworks-00300
+  - technology-usage-test-frameworks-00310
+  - technology-usage-test-frameworks-00320
+  - technology-usage-test-frameworks-00330
+  - technology-usage-test-frameworks-00340
+  - technology-usage-test-frameworks-00350
+  - technology-usage-test-frameworks-00360
+  - technology-usage-test-frameworks-00370
+  - technology-usage-web-01000
+  - technology-usage-web-01100
+  - technology-usage-web-01100
+  - technology-usage-web-01200
+  - technology-usage-web-01300
+  - technology-usage-web-01300
+  - technology-usage-web-01400
+  - technology-usage-web-01400
+  - technology-usage-web-01500
+  - technology-usage-web-01500
+  - technology-usage-web-01600
+  - technology-usage-web-01600
+  - technology-usage-web-01700
+  - technology-usage-web-01700
+  - technology-usage-web-01800
+  - technology-usage-web-01800
+  - technology-usage-web-01900
+  - technology-usage-web-01900
+  - technology-usage-web-02000
+  - technology-usage-web-02000
+  - technology-usage-web-02100
+  - technology-usage-web-02100
+  - technology-usage-web-02200
+  - technology-usage-web-02200
+  - technology-usage-web-02300
+  - technology-usage-web-02300
+  - technology-usage-web-02400
+  - technology-usage-web-02400
+  - test-frameworks-sauge-00010
+  - test-frameworks-sauge-00020
+  - test-frameworks-sauge-00030
+  - test-frameworks-sauge-00040
+  - test-frameworks-sauge-00050
+  - test-frameworks-sauge-00060
+  - test-frameworks-sauge-00070
+  - test-frameworks-sauge-00080
+  - test-frameworks-sauge-00090
+  - test-frameworks-sauge-00100
+  - test-frameworks-sauge-00110
+  - test-frameworks-sauge-00120
+  - test-frameworks-sauge-00130
+  - test-frameworks-sauge-00140
+  - test-frameworks-sauge-00150
+  - test-frameworks-sauge-00160
+  - test-frameworks-sauge-00170
+  - test-frameworks-sauge-00180
+  - test-frameworks-sauge-00190
+  - test-frameworks-sauge-00200
+  - test-frameworks-sauge-00210
+  - test-frameworks-sauge-00220
+  - test-frameworks-sauge-00230
+  - test-frameworks-sauge-00240
+  - test-frameworks-sauge-00260
+  - test-frameworks-sauge-00270
+  - test-frameworks-sauge-00280
+  - test-frameworks-sauge-00290
+  - test-frameworks-sauge-00300
+  - test-frameworks-sauge-00310
+  - test-frameworks-sauge-00320
+  - test-frameworks-sauge-00330
+  - test-frameworks-sauge-00340
+  - test-frameworks-sauge-00350
+  - test-frameworks-sauge-00360
+  - test-frameworks-sauge-00370
+  - test-frameworks-sauge-00560
+  - web-01000

--- a/hack/examples/issues.yaml
+++ b/hack/examples/issues.yaml
@@ -1,0 +1,2257 @@
+- name: cloud-readiness
+  description: This ruleset detects logging configurations that may be problematic when migrating an application to a cloud environment.
+  violations:
+    local-storage-00001:
+      description: File system - Java IO
+      category: mandatory
+      labels:
+      - konveyor.io/source
+      - konveyor.io/target=cloud-readiness
+      - storage
+      incidents:
+      - uri: file:///cache/m2/io/konveyor/demo/config-utils/1.0.0/io/konveyor/demo/config/ApplicationConfiguration.java
+        message: |-
+          An application running inside a container could lose access to a file in local storage.
+
+           Recommendations
+
+           The following recommendations depend on the function of the file in local storage:
+
+           * Logging: Log to standard output and use a centralized log collector to analyze the logs.
+           * Caching: Use a cache backing service.
+           * Configuration: Store configuration settings in environment variables so that they can be updated without code changes.
+           * Data storage: Use a database backing service for relational data or use a persistent data storage system.
+           * Temporary data storage: Use the file system of a running container as a brief, single-transaction cache.
+        codeSnip: " 4  import java.io.InputStream;\n 5  import java.util.Properties;\n 6  \n 7  public class ApplicationConfiguration {\n 8     private Properties config = this.loadProperties();\n 9  \n10     private Properties loadProperties() {\n11        Properties properties = new Properties();\n12  \n13        try {\n14           InputStream inputStream = new FileInputStream(\"/home/rroman/persistence.properties\");\n15  \n16           try {\n17              properties.load(inputStream);\n18           } catch (Throwable var6) {\n19              try {\n20                 inputStream.close();\n21              } catch (Throwable var5) {\n22                 var6.addSuppressed(var5);\n23              }\n24  "
+        lineNumber: 14
+        variables:
+          file: file:///cache/m2/io/konveyor/demo/config-utils/1.0.0/io/konveyor/demo/config/ApplicationConfiguration.java
+          kind: Constructor
+          name: loadProperties
+          package: io.konveyor.demo.config
+      links:
+      - url: https://docs.openshift.com/container-platform/4.5/builds/creating-build-inputs.html#builds-input-secrets-configmaps_creating-build-inputs
+        title: 'OpenShift Container Platform: Input secrets and ConfigMaps'
+      - url: https://docs.openshift.com/container-platform/4.5/logging/cluster-logging.html
+        title: 'OpenShift Container Platform: Understanding cluster logging'
+      - url: https://docs.openshift.com/container-platform/4.5/storage/understanding-persistent-storage.html
+        title: 'OpenShift Container Platform: Understanding persistent storage'
+      - url: https://12factor.net/backing-services
+        title: 'Twelve-Factor App: Backing services'
+      - url: https://12factor.net/config
+        title: 'Twelve-Factor App: Config'
+      - url: https://12factor.net/logs
+        title: 'Twelve-Factor App: Logs'
+      effort: 1
+  unmatched:
+  - embedded-cache-libraries-01000
+  - embedded-cache-libraries-02000
+  - embedded-cache-libraries-03000
+  - embedded-cache-libraries-04000
+  - embedded-cache-libraries-05000
+  - embedded-cache-libraries-06000
+  - embedded-cache-libraries-07000
+  - embedded-cache-libraries-08000
+  - embedded-cache-libraries-09000
+  - embedded-cache-libraries-10000
+  - embedded-cache-libraries-11000
+  - embedded-cache-libraries-12000
+  - embedded-cache-libraries-13000
+  - embedded-cache-libraries-14000
+  - embedded-cache-libraries-15000
+  - embedded-cache-libraries-16000
+  - java-corba-00000
+  - java-rmi-00000
+  - java-rmi-00000
+  - java-rmi-00001
+  - java-rpc-00000
+  - jca-00000
+  - jni-native-code-00000
+  - jni-native-code-00001
+  - local-storage-00002
+  - local-storage-00003
+  - local-storage-00004
+  - local-storage-00005
+  - local-storage-00006
+  - localhost-http-00001
+  - localhost-jdbc-00002
+  - localhost-ws-00003
+  - logging-0000
+  - logging-0000
+  - logging-0001
+  - logging-0001
+  - mail-00000
+  - session-00000
+  - session-00001
+  - socket-communication-00000
+  - socket-communication-00001
+- name: discovery-rules
+  tags:
+  - EJB XML
+  - Java Source
+  - Maven XML
+  - Properties
+  violations:
+    hardcoded-ip-address:
+      description: Hardcoded IP Address
+      category: mandatory
+      labels:
+      - discovery
+      - konveyor.io/target=cloud-readiness
+      - konveyor.io/target=discovery
+      incidents:
+      - uri: file:///shared/source/tackle-testapp/src/main/resources/persistence.properties
+        message: When migrating environments, hard-coded IP addresses may need to be modified or eliminated.
+        codeSnip: " 1   jdbc.driverClassName=oracle.jdbc.driver.OracleDriver\n 2   jdbc.url=jdbc:oracle:thin:@10.19.2.93:1521:xe\n 3   jdbc.user=customers\n 4   jdbc.password=customers\n 5   hibernate.hbm2ddl.auto=create-drop\n 6   hibernate.dialect=org.hibernate.dialect.OracleDialect\n 7  \n 8  # PostgreSQL\n 9  #jdbc.driverClassName=org.postgresql.Driver \n10  #jdbc.url=jdbc:postgresql://customers-postgresql:5432/customers\n11  #jdbc.user=customers\n12  #jdbc.password=customers\n13  #hibernate.hbm2ddl.auto=create-drop"
+        lineNumber: 2
+        variables:
+          matchingText: 10.19.2.93
+      effort: 1
+  insights:
+    discover-java-files:
+      description: Java source files
+      labels:
+      - discovery
+      - konveyor.io/include=always
+      - konveyor.io/target=discovery
+      - tag=Java Source
+      incidents:
+      - uri: file:///shared/source/tackle-testapp/src/main/java/io/konveyor/demo/ordermanagement/OrderManagementAppInitializer.java
+        message: ""
+      - uri: file:///shared/source/tackle-testapp/src/main/java/io/konveyor/demo/ordermanagement/config/PersistenceConfig.java
+        message: ""
+      - uri: file:///shared/source/tackle-testapp/src/main/java/io/konveyor/demo/ordermanagement/config/WebConfig.java
+        message: ""
+      - uri: file:///shared/source/tackle-testapp/src/main/java/io/konveyor/demo/ordermanagement/controller/CustomerController.java
+        message: ""
+      - uri: file:///shared/source/tackle-testapp/src/main/java/io/konveyor/demo/ordermanagement/exception/ResourceNotFoundException.java
+        message: ""
+      - uri: file:///shared/source/tackle-testapp/src/main/java/io/konveyor/demo/ordermanagement/exception/handler/ExceptionHandlingController.java
+        message: ""
+      - uri: file:///shared/source/tackle-testapp/src/main/java/io/konveyor/demo/ordermanagement/model/Customer.java
+        message: ""
+      - uri: file:///shared/source/tackle-testapp/src/main/java/io/konveyor/demo/ordermanagement/repository/CustomerRepository.java
+        message: ""
+      - uri: file:///shared/source/tackle-testapp/src/main/java/io/konveyor/demo/ordermanagement/service/CustomerService.java
+        message: ""
+    discover-maven-xml:
+      description: Maven XML file
+      labels:
+      - discovery
+      - konveyor.io/include=always
+      - konveyor.io/target=discovery
+      - tag=Maven XML
+      incidents:
+      - uri: file:///shared/source/tackle-testapp/pom.xml
+        message: ""
+    discover-properties-file:
+      description: Properties file
+      labels:
+      - discovery
+      - konveyor.io/include=always
+      - konveyor.io/target=discovery
+      - tag=Properties
+      incidents:
+      - uri: file:///shared/source/tackle-testapp/src/main/resources/persistence.properties
+        message: ""
+    windup-discover-ejb-configuration:
+      description: EJB XML Configuration
+      labels:
+      - discovery
+      - konveyor.io/include=always
+      - konveyor.io/target=discovery
+      - tag=EJB XML
+      incidents:
+      - uri: file:///shared/source/tackle-testapp/pom.xml
+        message: ""
+        codeSnip: " 1  <project xmlns=\"http://maven.apache.org/POM/4.0.0\"\n 2  \txmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"\n 3  \txsi:schemaLocation=\"http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd\">\n 4  \t<modelVersion>4.0.0</modelVersion>\n 5  \t<groupId>io.konveyor.demo</groupId>\n 6  \t<artifactId>customers-tomcat</artifactId>\n 7  \t<version>0.0.1-SNAPSHOT</version>\n 8  \n 9  \t<name>Order Management</name>\n10  \t<packaging>war</packaging>\n11  \t<description>Remaining services for the legacy Order Management application</description>\n12  \n13  \t<properties>\n14  \t\t<java.version>1.8</java.version>\n15  \t\t<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>"
+        lineNumber: 4
+        variables:
+          data: ""
+          innerText: "\n\t4.0.0\n\tio.konveyor.demo\n\tcustomers-tomcat\n\t0.0.1-SNAPSHOT\n\n\tOrder Management\n\twar\n\tRemaining services for the legacy Order Management application\n\n\t\n\t\t1.8\n\t\tUTF-8\n\t\tUTF-8\n\t\t${java.version}\n\t\t${java.version}\n\t\t5.3.7\n\t\t9.0.46\n\t\t2021.0.1\n\t\t5.4.32.Final\n\t\t6.2.0.Final\n\n\t\t42.2.20\n\t\t2.12.3\n\n\t\t3.8.1\n\t\t3.3.1\n\t\t3.2.0\n\n\t\n\n\t\n\t\t\n\t\t\t\n\t\t\t\tcom.fasterxml.jackson\n\t\t\t\tjackson-bom\n\t\t\t\t${jackson.version}\n\t\t\t\timport\n\t\t\t\tpom\n\t\t\t\n\t\t\t\n\t\t\t\torg.springframework.data\n\t\t\t\tspring-data-bom\n\t\t\t\t${spring-data.version}\n\t\t\t\timport\n\t\t\t\tpom\n\t\t\t\n\t\t\n\t\n\t\n\t\t\n\t\t\torg.apache.tomcat\n\t\t\ttomcat-servlet-api\n\t\t\t${tomcat.version}\n\t\t\tprovided\n\t\t\n\t\t\n\t\t\tcom.fasterxml.jackson.core\n\t\t\tjackson-core\n\t\t\n\t\t\n\t\t\tcom.fasterxml.jackson.core\n\t\t\tjackson-databind\n\t\t\n\t\t\n\t\t\torg.springframework.data\n\t\t\tspring-data-jpa\n\t\t\n\n\t\t\n\t\t\torg.springframework\n\t\t\tspring-jdbc\n\t\t\t${spring-framework.version}\n\t\t\n\t\t\n\t\t\torg.springframework\n\t\t\tspring-webmvc\n\t\t\t${spring-framework.version}\n\t\t\n\t\t\n\t\t\torg.springframework\n\t\t\tspring-web\n\t\t\t${spring-framework.version}\n\t\t\n\t\t\n\t\t\torg.springframework.boot\n\t\t\tspring-boot-starter-actuator\n\t\t\t2.5.0\n\t\t\n\t\t\n\t\t\torg.apache.tomcat\n\t\t\ttomcat-jdbc\n\t\t\t${tomcat.version}\n\t\t\truntime\n\t\t\n\t\t\n\t\t\torg.hibernate\n\t\t\thibernate-entitymanager\n\t\t\t${hibernate.version}\n\t\t\n\t\t\n\t\t\torg.hibernate.validator\n\t\t\thibernate-validator\n\t\t\t${hibernate-validator.version}\n\t\t\n\t\t\n\t\t\tch.qos.logback\n\t\t\tlogback-classic\n\t\t\t1.1.7\n\t\t\n\t\t\n\t\t\tcom.oracle.database.jdbc\n\t\t\tojdbc11\n\t\t\t21.1.0.0\n\t\t\n\t\t\n\t\t\torg.postgresql\n\t\t\tpostgresql\n\t\t\t42.2.23\n\t\t\n\t\t\n\t\t\n\t\t\tio.konveyor.demo\n\t\t\tconfig-utils\n\t\t\t1.0.0\n\t\t\n\n\t\n\t\n\t\t\n\t\t\t\n\t\t\t\torg.apache.maven.plugins\n\t\t\t\tmaven-compiler-plugin\n\t\t\t\t${maven-compiler-plugin.version}\n\t\t\t\n\t\t\t\n\t\t\t\torg.apache.maven.plugins\n\t\t\t\tmaven-war-plugin\n\t\t\t\t${maven-war-plugin.version}\n\t\t\t\t\n\t\t\t\t\tfalse\n\t\t\t\t\n\t\t\t\n\t\t\t\n\t\t\t\torg.apache.maven.plugins\n\t\t\t\tmaven-resources-plugin\n\t\t\t\t${maven-resources-plugin.version}\n\t\t\t\t\n\t\t\t\t\tUTF-8\n\t\t\t\t\n\t\t\t\n\t\t\n\t\n\t\n   \n     tackle-testapp\n     GitHub rromannissen Apache Maven Packages\n     https://maven.pkg.github.com/konveyor/tackle-testapp\n   \n\n\n\n"
+          matchingXML: <?xml?><project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd"><modelVersion>4.0.0</modelVersion><groupId>io.konveyor.demo</groupId><artifactId>customers-tomcat</artifactId><version>0.0.1-SNAPSHOT</version><name>Order Management</name><packaging>war</packaging><description>Remaining services for the legacy Order Management application</description><properties><java.version>1.8</java.version><project.build.sourceEncoding>UTF-8</project.build.sourceEncoding><project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding><maven.compiler.source>${java.version}</maven.compiler.source><maven.compiler.target>${java.version}</maven.compiler.target><spring-framework.version>5.3.7</spring-framework.version><tomcat.version>9.0.46</tomcat.version><spring-data.version>2021.0.1</spring-data.version><hibernate.version>5.4.32.Final</hibernate.version><hibernate-validator.version>6.2.0.Final</hibernate-validator.version><postgresql-driver.version>42.2.20</postgresql-driver.version><jackson.version>2.12.3</jackson.version><maven-compiler-plugin.version>3.8.1</maven-compiler-plugin.version><maven-war-plugin.version>3.3.1</maven-war-plugin.version><maven-resources-plugin.version>3.2.0</maven-resources-plugin.version></properties><dependencyManagement><dependencies><dependency><groupId>com.fasterxml.jackson</groupId><artifactId>jackson-bom</artifactId><version>${jackson.version}</version><scope>import</scope><type>pom</type></dependency><dependency><groupId>org.springframework.data</groupId><artifactId>spring-data-bom</artifactId><version>${spring-data.version}</version><scope>import</scope><type>pom</type></dependency></dependencies></dependencyManagement><dependencies><dependency><groupId>org.apache.tomcat</groupId><artifactId>tomcat-servlet-api</artifactId><version>${tomcat.version}</version><scope>provided</scope></dependency><dependency><groupId>com.fasterxml.jackson.core</groupId><artifactId>jackson-core</artifactId></dependency><dependency><groupId>com.fasterxml.jackson.core</groupId><artifactId>jackson-databind</artifactId></dependency><dependency><groupId>org.springframework.data</groupId><artifactId>spring-data-jpa</artifactId></dependency><dependency><groupId>org.springframework</groupId><artifactId>spring-jdbc</artifactId><version>${spring-framework.version}</version></dependency><dependency><groupId>org.springframework</groupId><artifactId>spring-webmvc</artifactId><version>${spring-framework.version}</version></dependency><dependency><groupId>org.springframework</groupId><artifactId>spring-web</artifactId><version>${spring-framework.version}</version></dependency><dependency><groupId>org.springframework.boot</groupId><artifactId>spring-boot-starter-actuator</artifactId><version>2.5.0</version></dependency><dependency><groupId>org.apache.tomcat</groupId><artifactId>tomcat-jdbc</artifactId><version>${tomcat.version}</version><scope>runtime</scope></dependency><dependency><groupId>org.hibernate</groupId><artifactId>hibernate-entitymanager</artifactId><version>${hibernate.version}</version></dependency><dependency><groupId>org.hibernate.validator</groupId><artifactId>hibernate-validator</artifactId><version>${hibernate-validator.version}</version></dependency><dependency><groupId>ch.qos.logback</groupId><artifactId>logback-classic</artifactId><version>1.1.7</version></dependency><dependency><groupId>com.oracle.database.jdbc</groupId><artifactId>ojdbc11</artifactId><version>21.1.0.0</version></dependency><dependency><groupId>org.postgresql</groupId><artifactId>postgresql</artifactId><version>42.2.23</version></dependency><!-- Corporate libraries --><dependency><groupId>io.konveyor.demo</groupId><artifactId>config-utils</artifactId><version>1.0.0</version></dependency></dependencies><build><plugins><plugin><groupId>org.apache.maven.plugins</groupId><artifactId>maven-compiler-plugin</artifactId><version>${maven-compiler-plugin.version}</version></plugin><plugin><groupId>org.apache.maven.plugins</groupId><artifactId>maven-war-plugin</artifactId><version>${maven-war-plugin.version}</version><configuration><failOnMissingWebXml>false</failOnMissingWebXml></configuration></plugin><plugin><groupId>org.apache.maven.plugins</groupId><artifactId>maven-resources-plugin</artifactId><version>${maven-resources-plugin.version}</version><configuration><encoding>UTF-8</encoding></configuration></plugin></plugins></build><distributionManagement><repository><id>tackle-testapp</id><name>GitHub rromannissen Apache Maven Packages</name><url>https://maven.pkg.github.com/konveyor/tackle-testapp</url></repository></distributionManagement></project>
+      - uri: file:///shared/source/tackle-testapp/rules/corporate-framework-config.windup.xml
+        message: ""
+        codeSnip: |2-
+           1  <?xml version="1.0"?>
+           2  <ruleset id="corporate-configuration"
+           3           xmlns="http://windup.jboss.org/schema/jboss-ruleset"
+           4           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           5           xsi:schemaLocation="http://windup.jboss.org/schema/jboss-ruleset http://windup.jboss.org/schema/jboss-ruleset/windup-jboss-ruleset.xsd">
+           6      <metadata>
+           7          <description>
+           8              This ruleset provides rules related to the corporate configuration frameworks.
+           9          </description>
+          10          <dependencies>
+          11            <addon id="org.jboss.windup.rules,windup-rules-javaee,3.0.0.Final"/>
+          12            <addon id="org.jboss.windup.rules,windup-rules-java,3.0.0.Final"/>
+          13          </dependencies>
+          14          <sourceTechnology id="traditional-corporate-framework"/>
+          15          <targetTechnology id="cloud-corporate-framework"/>
+          16          <tag>configuration</tag>
+        lineNumber: 5
+        variables:
+          data: ""
+          innerText: "\n\n    \n        \n            This ruleset provides rules related to the corporate configuration frameworks.\n        \n        \n          \n          \n        \n        \n        \n        configuration\n    \n    \n        \n            \n                \n                    VARIABLE_DECLARATION\n                \n            \n            \n                \n                    \n                        The legacy ApplicationConfiguration class is being used in this application. This is discouraged by the migration\n                        guidelines, and should be replaced by a more standard approach using Spring's @PropertySource annotation and Environment class:\n\n\n                        ```java\n                        @PropertySource(\"classpath:persistence.properties\")\n                        public class PersistenceConfig {\n                          @Autowired\n                          private Environment env;\n\n                          @Bean\n                          public DataSource dataSource() {\n                            final DriverManagerDataSource dataSource = new DriverManagerDataSource();\n                            dataSource.setDriverClassName(env.getProperty(\"jdbc.driverClassName\"));\n                            dataSource.setUrl(env.getProperty(\"jdbc.url\"));\n                            dataSource.setUsername(env.getProperty(\"jdbc.user\"));\n                            dataSource.setPassword(env.getProperty(\"jdbc.password\"));\n\n                            return dataSource;\n                          }\n                        }\n                        ```\n\n\n\n                        This allows externalizing the configuration in Kubernetes by injecting it as a ConfigMap or a Secret in the lib directory from the\n                        container running the Tomcat instance.\n                    \n                    \n                    \n                    \n                    configuration\n                \n            \n        \n      \n\n"
+          matchingXML: |-
+            <?xml version="1.0"?><ruleset id="corporate-configuration" xmlns="http://windup.jboss.org/schema/jboss-ruleset" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://windup.jboss.org/schema/jboss-ruleset http://windup.jboss.org/schema/jboss-ruleset/windup-jboss-ruleset.xsd"><metadata><description>This ruleset provides rules related to the corporate configuration frameworks.</description><dependencies><addon id="org.jboss.windup.rules,windup-rules-javaee,3.0.0.Final"></addon><addon id="org.jboss.windup.rules,windup-rules-java,3.0.0.Final"></addon></dependencies><sourceTechnology id="traditional-corporate-framework"></sourceTechnology><targetTechnology id="cloud-corporate-framework"></targetTechnology><tag>configuration</tag></metadata><rules><rule id="corporate-config-01000" xmlns="http://windup.jboss.org/schema/jboss-ruleset"><when><javaclass references="io.konveyor.demo.config.ApplicationConfiguration"><location>VARIABLE_DECLARATION</location></javaclass></when><perform><hint title="Legacy configuration with io.konveyor.demo.config.ApplicationConfiguration" effort="1" category-id="cloud-mandatory"><message>The legacy ApplicationConfiguration class is being used in this application. This is discouraged by the migration
+                                    guidelines, and should be replaced by a more standard approach using Spring&#39;s @PropertySource annotation and Environment class:
+
+
+                                    ```java
+                                    @PropertySource(&#34;classpath:persistence.properties&#34;)
+                                    public class PersistenceConfig {
+                                      @Autowired
+                                      private Environment env;
+
+                                      @Bean
+                                      public DataSource dataSource() {
+                                        final DriverManagerDataSource dataSource = new DriverManagerDataSource();
+                                        dataSource.setDriverClassName(env.getProperty(&#34;jdbc.driverClassName&#34;));
+                                        dataSource.setUrl(env.getProperty(&#34;jdbc.url&#34;));
+                                        dataSource.setUsername(env.getProperty(&#34;jdbc.user&#34;));
+                                        dataSource.setPassword(env.getProperty(&#34;jdbc.password&#34;));
+
+                                        return dataSource;
+                                      }
+                                    }
+                                    ```
+
+
+
+                                    This allows externalizing the configuration in Kubernetes by injecting it as a ConfigMap or a Secret in the lib directory from the
+                                    container running the Tomcat instance.</message><link title="Spring Documentation - PropertySource javadoc" href="https://docs.spring.io/spring-framework/docs/current/javadoc-api/org/springframework/context/annotation/PropertySource.html"></link><link title="Mkyong - Spring @PropertySource example" href="https://mkyong.com/spring/spring-propertysources-example/"></link><link title="Baeldung - Properties with Spring and Spring Boot" href="https://www.baeldung.com/properties-with-spring"></link><tag>configuration</tag></hint></perform></rule></rules></ruleset>
+      - uri: file:///shared/source/tackle-testapp/rules/no-target/test4.windup.xml
+        message: ""
+        codeSnip: " 1  <?xml version=\"1.0\"?>\n 2  <ruleset id=\"Test-004\" xmlns=\"http://windup.jboss.org/schema/jboss-ruleset\"\n 3  \txmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"\n 4  \txsi:schemaLocation=\"http://windup.jboss.org/schema/jboss-ruleset http://windup.jboss.org/schema/jboss-ruleset/windup-jboss-ruleset.xsd\">\n 5  \t<metadata>\n 6  \t\t<description>\n 7              \tThis is a description of rules. This is a template for new rulesets. Change this.\n 8          \t</description>\n 9  \t\t\t<!-- version ranges applied to from and to technologies -->\n10  \t\t<dependencies>\n11      \t\t\t<addon id=\"org.jboss.windup.rules,windup-rules-xml,3.0.0.Final\"/>\n12  \t\t</dependencies>\n13  \n14  \t</metadata>\n15  \t<rules>"
+        lineNumber: 4
+        variables:
+          data: ""
+          innerText: "\n\n\t\n\t\t\n            \tThis is a description of rules. This is a template for new rulesets. Change this.\n        \t\n\t\t\t\n\t\t\n    \t\t\t\n\t\t\n\n\t\n\t\n\t\t\n\t\t\t\n\t\t\t\n\t\t\t\t\n\n\t\t\t\n\t\t\t\n\t\t\t\n\t\t\t\t\n\t\t\t\t\tTest-002 Message markdown\n\t\t\t\t\tlink\n\t\t\t\t\ttag\n\t\t\t\t\n\n\t\t\t\n\t\t\n\t\n\n"
+          matchingXML: <?xml version="1.0"?><ruleset id="Test-004" xmlns="http://windup.jboss.org/schema/jboss-ruleset" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://windup.jboss.org/schema/jboss-ruleset http://windup.jboss.org/schema/jboss-ruleset/windup-jboss-ruleset.xsd"><metadata><description>This is a description of rules. This is a template for new rulesets. Change this.</description><!-- version ranges applied to from and to technologies --><dependencies><addon id="org.jboss.windup.rules,windup-rules-xml,3.0.0.Final"></addon></dependencies></metadata><rules><rule id="Test-004-00001"><!-- rule condition, when it could be fired --><when><file filename="AdministracionEfectivo-jpa{*}.jar"></file></when><!-- rule operation, what to do if it is fired --><perform><hint title="Test-002 Remote Exception" effort="0" category-id="potential"><message><![CDATA[Test-002 Message markdown]]></message><link href="http://nufc.com" title="Test-002 Test link">link</link><tag>tag</tag></hint></perform></rule></rules></ruleset>
+      - uri: file:///shared/source/tackle-testapp/rules/no-target/test5.windup.xml
+        message: ""
+        codeSnip: " 1  <?xml version=\"1.0\"?>\n 2  <ruleset id=\"Test-005\" xmlns=\"http://windup.jboss.org/schema/jboss-ruleset\"\n 3  \txmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"\n 4  \txsi:schemaLocation=\"http://windup.jboss.org/schema/jboss-ruleset http://windup.jboss.org/schema/jboss-ruleset/windup-jboss-ruleset.xsd\">\n 5  \t<metadata>\n 6  \t\t<description>\n 7              \tThis is a description of rules. This is a template for new rulesets. Change this.\n 8          \t</description>\n 9  \t\t\t<!-- version ranges applied to from and to technologies -->\n10  \t\t<dependencies>\n11      \t\t\t<addon id=\"org.jboss.windup.rules,windup-rules-xml,3.0.0.Final\"/>\n12  \t\t</dependencies>\n13  \n14  \t</metadata>\n15  \t<rules>"
+        lineNumber: 4
+        variables:
+          data: ""
+          innerText: "\n\n\t\n\t\t\n            \tThis is a description of rules. This is a template for new rulesets. Change this.\n        \t\n\t\t\t\n\t\t\n    \t\t\t\n\t\t\n\n\t\n\t\n\t\t\n\t\t\t\n\t\t\t\n\t\t\t\t\n\n\t\t\t\n\t\t\t\n\t\t\t\n\t\t\t\t\n\t\t\t\t\tTest-002 Message markdown\n\t\t\t\t\tlink\n\t\t\t\t\ttag\n\t\t\t\t\n\n\t\t\t\n\t\t\n\t\n\n"
+          matchingXML: <?xml version="1.0"?><ruleset id="Test-005" xmlns="http://windup.jboss.org/schema/jboss-ruleset" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://windup.jboss.org/schema/jboss-ruleset http://windup.jboss.org/schema/jboss-ruleset/windup-jboss-ruleset.xsd"><metadata><description>This is a description of rules. This is a template for new rulesets. Change this.</description><!-- version ranges applied to from and to technologies --><dependencies><addon id="org.jboss.windup.rules,windup-rules-xml,3.0.0.Final"></addon></dependencies></metadata><rules><rule id="Test-005-00001"><!-- rule condition, when it could be fired --><when><file filename="AdministracionEfectivo-jpa{*}.jar"></file></when><!-- rule operation, what to do if it is fired --><perform><hint title="Test-002 Remote Exception" effort="0" category-id="potential"><message><![CDATA[Test-002 Message markdown]]></message><link href="http://nufc.com" title="Test-002 Test link">link</link><tag>tag</tag></hint></perform></rule></rules></ruleset>
+      - uri: file:///shared/source/tackle-testapp/rules/test.windup.xml
+        message: ""
+        codeSnip: " 1  <?xml version=\"1.0\"?>\n 2  <ruleset id=\"Test-001\" xmlns=\"http://windup.jboss.org/schema/jboss-ruleset\"\n 3  \txmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"\n 4  \txsi:schemaLocation=\"http://windup.jboss.org/schema/jboss-ruleset http://windup.jboss.org/schema/jboss-ruleset/windup-jboss-ruleset.xsd\">\n 5  \t<metadata>\n 6  \t\t<description>\n 7              \tThis is a description of rules. This is a template for new rulesets. Change this.\n 8          \t</description>\n 9  \t\t\t<!-- version ranges applied to from and to technologies -->\n10  \t\t<dependencies>\n11      \t\t\t<addon id=\"org.jboss.windup.rules,windup-rules-xml,3.0.0.Final\"/>\n12  \t\t</dependencies>\n13  \n14  \t</metadata>\n15  \t<rules>"
+        lineNumber: 4
+        variables:
+          data: ""
+          innerText: "\n\n\t\n\t\t\n            \tThis is a description of rules. This is a template for new rulesets. Change this.\n        \t\n\t\t\t\n\t\t\n    \t\t\t\n\t\t\n\n\t\n\t\n\t\t\n\t\t\t\n\t\t\t\n\t\t\t\t\n\n\t\t\t\n\t\t\t\n\t\t\t\n\t\t\t\t\n\t\t\t\t\tTest-002 Message markdown\n\t\t\t\t\tlink\n\t\t\t\t\ttag\n\t\t\t\t\n\n\t\t\t\n\t\t\n\t\n\n"
+          matchingXML: <?xml version="1.0"?><ruleset id="Test-001" xmlns="http://windup.jboss.org/schema/jboss-ruleset" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://windup.jboss.org/schema/jboss-ruleset http://windup.jboss.org/schema/jboss-ruleset/windup-jboss-ruleset.xsd"><metadata><description>This is a description of rules. This is a template for new rulesets. Change this.</description><!-- version ranges applied to from and to technologies --><dependencies><addon id="org.jboss.windup.rules,windup-rules-xml,3.0.0.Final"></addon></dependencies></metadata><rules><rule id="Test-001-00001"><!-- rule condition, when it could be fired --><when><file filename="AdministracionEfectivo-jpa{*}.jar"></file></when><!-- rule operation, what to do if it is fired --><perform><hint title="Test-002 Remote Exception" effort="0" category-id="potential"><message><![CDATA[Test-002 Message markdown]]></message><link href="http://nufc.com" title="Test-002 Test link">link</link><tag>tag</tag></hint></perform></rule></rules></ruleset>
+      - uri: file:///shared/source/tackle-testapp/rules/test2.windup.xml
+        message: ""
+        codeSnip: " 1  <?xml version=\"1.0\"?>\n 2  <ruleset id=\"Test-002\" xmlns=\"http://windup.jboss.org/schema/jboss-ruleset\"\n 3  \txmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"\n 4  \txsi:schemaLocation=\"http://windup.jboss.org/schema/jboss-ruleset http://windup.jboss.org/schema/jboss-ruleset/windup-jboss-ruleset.xsd\">\n 5  \t<metadata>\n 6  \t\t<description>\n 7              \tThis is a description of rules. This is a template for new rulesets. Change this.\n 8          \t</description>\n 9  \t\t\t<!-- version ranges applied to from and to technologies -->\n10  \t\t<dependencies>\n11      \t\t\t<addon id=\"org.jboss.windup.rules,windup-rules-xml,3.0.0.Final\"/>\n12  \t\t</dependencies>\n13  \n14  \t</metadata>\n15  \t<rules>"
+        lineNumber: 4
+        variables:
+          data: ""
+          innerText: "\n\n\t\n\t\t\n            \tThis is a description of rules. This is a template for new rulesets. Change this.\n        \t\n\t\t\t\n\t\t\n    \t\t\t\n\t\t\n\n\t\n\t\n\t\t\n\t\t\t\n\t\t\t\n\t\t\t\t\n\n\t\t\t\n\t\t\t\n\t\t\t\n\t\t\t\t\n\t\t\t\t\tTest-002 Message markdown\n\t\t\t\t\tlink\n\t\t\t\t\ttag\n\t\t\t\t\n\n\t\t\t\n\t\t\n\t\n\n"
+          matchingXML: <?xml version="1.0"?><ruleset id="Test-002" xmlns="http://windup.jboss.org/schema/jboss-ruleset" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://windup.jboss.org/schema/jboss-ruleset http://windup.jboss.org/schema/jboss-ruleset/windup-jboss-ruleset.xsd"><metadata><description>This is a description of rules. This is a template for new rulesets. Change this.</description><!-- version ranges applied to from and to technologies --><dependencies><addon id="org.jboss.windup.rules,windup-rules-xml,3.0.0.Final"></addon></dependencies></metadata><rules><rule id="Test-002-00001"><!-- rule condition, when it could be fired --><when><file filename="AdministracionEfectivo-jpa{*}.jar"></file></when><!-- rule operation, what to do if it is fired --><perform><hint title="Test-002 Remote Exception" effort="0" category-id="potential"><message><![CDATA[Test-002 Message markdown]]></message><link href="http://nufc.com" title="Test-002 Test link">link</link><tag>tag</tag></hint></perform></rule></rules></ruleset>
+      - uri: file:///shared/source/tackle-testapp/rules/test3-nosuffix.xml
+        message: ""
+        codeSnip: " 1  <?xml version=\"1.0\"?>\n 2  <ruleset id=\"Test-003\" xmlns=\"http://windup.jboss.org/schema/jboss-ruleset\"\n 3  \txmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"\n 4  \txsi:schemaLocation=\"http://windup.jboss.org/schema/jboss-ruleset http://windup.jboss.org/schema/jboss-ruleset/windup-jboss-ruleset.xsd\">\n 5  \t<metadata>\n 6  \t\t<description>\n 7              \tThis is a description of rules. This is a template for new rulesets. Change this.\n 8          \t</description>\n 9  \t\t\t<!-- version ranges applied to from and to technologies -->\n10  \t\t<dependencies>\n11      \t\t\t<addon id=\"org.jboss.windup.rules,windup-rules-xml,3.0.0.Final\"/>\n12  \t\t</dependencies>\n13  \n14  \t</metadata>\n15  \t<rules>"
+        lineNumber: 4
+        variables:
+          data: ""
+          innerText: "\n\n\t\n\t\t\n            \tThis is a description of rules. This is a template for new rulesets. Change this.\n        \t\n\t\t\t\n\t\t\n    \t\t\t\n\t\t\n\n\t\n\t\n\t\t\n\t\t\t\n\t\t\t\n\t\t\t\t\n\n\t\t\t\n\t\t\t\n\t\t\t\n\t\t\t\t\n\t\t\t\t\tTest-002 Message markdown\n\t\t\t\t\tlink\n\t\t\t\t\ttag\n\t\t\t\t\n\n\t\t\t\n\t\t\n\t\n\n"
+          matchingXML: <?xml version="1.0"?><ruleset id="Test-003" xmlns="http://windup.jboss.org/schema/jboss-ruleset" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://windup.jboss.org/schema/jboss-ruleset http://windup.jboss.org/schema/jboss-ruleset/windup-jboss-ruleset.xsd"><metadata><description>This is a description of rules. This is a template for new rulesets. Change this.</description><!-- version ranges applied to from and to technologies --><dependencies><addon id="org.jboss.windup.rules,windup-rules-xml,3.0.0.Final"></addon></dependencies></metadata><rules><rule id="Test-003-00001"><!-- rule condition, when it could be fired --><when><file filename="AdministracionEfectivo-jpa{*}.jar"></file></when><!-- rule operation, what to do if it is fired --><perform><hint title="Test-002 Remote Exception" effort="0" category-id="potential"><message><![CDATA[Test-002 Message markdown]]></message><link href="http://nufc.com" title="Test-002 Test link">link</link><tag>tag</tag></hint></perform></rule></rules></ruleset>
+  unmatched:
+  - discover-license
+  - discover-manifest-file
+  - windup-discover-jpa-configuration
+  - windup-discover-spring-configuration
+  - windup-discover-web-configuration
+- name: eap7/weblogic/tests/data
+  unmatched:
+  - maven-javax-to-jakarta-00001
+  - maven-javax-to-jakarta-00002
+  - maven-javax-to-jakarta-00003
+  - maven-javax-to-jakarta-00004
+  - maven-javax-to-jakarta-00005
+  - maven-javax-to-jakarta-00006
+  - maven-javax-to-jakarta-00007
+  - maven-javax-to-jakarta-00008
+  - maven-javax-to-jakarta-00010
+  - maven-javax-to-jakarta-00011
+  - maven-javax-to-jakarta-00012
+  - maven-javax-to-jakarta-00013
+  - maven-javax-to-jakarta-00014
+  - maven-javax-to-jakarta-00015
+  - maven-javax-to-jakarta-00016
+  - maven-javax-to-jakarta-00017
+  skipped:
+  - base64-01000
+  - deprecated-singletonpolicy-00001
+  - eap6-08000
+  - eap6-08001
+  - eap6-08002
+  - eap6-11000
+  - eap6-12000
+  - eap6-xml-05000
+  - eap6-xml-06000
+  - eap7-websphere-xml-01000
+  - eap7-websphere-xml-02000
+  - eap7-websphere-xml-03500
+  - eap7-websphere-xml-06000
+  - eap7-websphere-xml-07000
+  - eap7-websphere-xml-08000
+  - eap7-websphere-xml-09000
+  - elytron-eap71-00000
+  - elytron-eap71-00010
+  - embedded-framework-libraries-01000
+  - embedded-framework-libraries-02000
+  - embedded-framework-libraries-04000
+  - embedded-framework-libraries-05000
+  - embedded-framework-libraries-06000
+  - hibernate4-00001
+  - hibernate4-00002
+  - hibernate4-00003
+  - hibernate4-00004
+  - hibernate4-00005
+  - hibernate4-00006
+  - hibernate4-00007
+  - hibernate4-00008
+  - hibernate4-00009
+  - hibernate4-00010
+  - hibernate4-00011
+  - hibernate4-00012
+  - hibernate4-00013
+  - hibernate4-00014
+  - hibernate4-00015
+  - hibernate4-00016
+  - hibernate4-00017
+  - hibernate4-00018
+  - hibernate4-00021
+  - hibernate4-00022
+  - hibernate4-00023
+  - hibernate4-00024
+  - hibernate4-00025
+  - hibernate4-00026
+  - hibernate4-00027
+  - hibernate4-00028
+  - hibernate4-00030
+  - hibernate4-00031
+  - hibernate4-00032
+  - hibernate4-00033
+  - hibernate4-00034
+  - hibernate4-00035
+  - hibernate4-00036
+  - hibernate4-00037
+  - hibernate4-00038
+  - hibernate4-00039
+  - hibernate4-00040
+  - hibernate4-xml-00001
+  - hibernate4-xml-00002
+  - hibernate4-xml-00003
+  - hibernate4-xml-00004
+  - hibernate4-xml-00005
+  - hibernate50-51-00000
+  - hibernate50-51-00100
+  - hibernate51-53-00001
+  - hibernate51-53-00100
+  - hibernate51-53-00300
+  - hibernate51-53-00400
+  - hibernate51-53-00401
+  - hibernate51-53-00402
+  - hibernate51-53-00403
+  - hibernate51-53-00404
+  - hibernate51-53-00405
+  - hibernate51-53-00406
+  - hibernate51-53-00407
+  - hibernate51-53-00500
+  - hibernate51-53-00600
+  - hibernate51-53-00700
+  - hibernate51-53-00701
+  - hibernate51-53-00702
+  - hibernate51-53-00800
+  - hibernate51-53-01000
+  - hibernate51-53-01001
+  - hibernate51-53-01100
+  - hibernate51-53-01200
+  - hsearch-00000
+  - hsearch-00001
+  - hsearch-00002
+  - hsearch-00003
+  - hsearch-00004
+  - hsearch-00005
+  - hsearch-00006
+  - hsearch-00007
+  - hsearch-00008
+  - hsearch-00009
+  - hsearch-00010
+  - hsearch-00011
+  - hsearch-00100
+  - hsearch-00101
+  - hsearch-00103
+  - hsearch-00104
+  - hsearch-00106
+  - hsearch-00107
+  - hsearch-00108
+  - hsearch-00109
+  - hsearch-00110
+  - hsearch-00111
+  - hsearch-00112
+  - hsearch-00113
+  - hsearch-00114
+  - hsearch-00115
+  - hsearch-00116
+  - hsearch-00117
+  - hsearch-00118
+  - hsearch-00119
+  - hsearch-00200
+  - hsearch-00201
+  - hsearch-00210
+  - hsearch-00211
+  - hsearch-00213
+  - hsearch-00214
+  - hsearch-00215
+  - hsearch-00216
+  - hsearch-00217
+  - hsearch-00218
+  - hsearch-00219
+  - hsearch-00220
+  - hsearch-00221
+  - hsearch-00222
+  - hsearch-00224
+  - hsearch-00225
+  - hsearch-00226
+  - hsearch-00227
+  - hsearch-00228
+  - hsearch-00229
+  - hsearch-00230
+  - hsearch-00231
+  - hsearch-00232
+  - hsearch-00233
+  - hsearch-00234
+  - hsearch-00235
+  - hsearch-00236
+  - hsearch-00237
+  - hsearch-00238
+  - hsearch-00239
+  - hsearch-00240
+  - jax-ws-00000
+  - jaxrpc-00000
+  - jboss-eap4and5to6and7-java-01000
+  - jboss-eap4and5to6and7-java-02000
+  - jboss-eap4and5to6and7-java-03000
+  - jboss-eap4and5to6and7-xml-01000
+  - jboss-eap4and5to6and7-xml-02000
+  - jboss-eap4and5to6and7-xml-03000
+  - jboss-eap4and5to6and7-xml-04000
+  - jboss-eap4and5to6and7-xml-05000
+  - jboss-eap4and5to6and7-xml-06000
+  - jboss-eap4and5to6and7-xml-07000
+  - jboss-eap5-7-java-02000
+  - jboss-eap5-7-java-03000
+  - jboss-eap5-7-java-05000
+  - jboss-eap5-7-java-06000
+  - jboss-eap5-7-java-07000
+  - jboss-eap5-7-java-08000
+  - jboss-eap5-7-java-08100
+  - jboss-eap5-7-java-08200
+  - jboss-eap5-7-java-08300
+  - jboss-eap5-7-java-08400
+  - jboss-eap5-7-java-08500
+  - jboss-eap5-7-java-08600
+  - jboss-eap5-7-java-08700
+  - jboss-eap5-7-java-08800
+  - jboss-eap5-7-java-08900
+  - jboss-eap5-7-java-09000
+  - jboss-eap5-7-java-09100
+  - jboss-eap5-7-xml-01000
+  - jboss-eap5-7-xml-02000
+  - jboss-eap5-7-xml-10000
+  - jboss-eap5-7-xml-13000
+  - jboss-eap5-7-xml-14000
+  - jboss-eap5-7-xml-16000
+  - jboss-eap5and6to7-java-01000
+  - jboss-eap5and6to7-java-02000
+  - jboss-eap5and6to7-java-03000
+  - jboss-eap5and6to7-java-04000
+  - jboss-eap5and6to7-java-05000
+  - jboss-eap5and6to7-java-06000
+  - jboss-eap5and6to7-java-07000
+  - jboss-eap5and6to7-java-08000
+  - jboss-eap5and6to7-java-09000
+  - jboss-eap5and6to7-xml-05000
+  - jboss-eap5and6to7-xml-06000
+  - jboss-eap5and6to7-xml-07000
+  - jboss-eap5and6to7-xml-09000
+  - jboss-eap5and6to7-xml-12000
+  - jboss-eap5and6to7-xml-17000
+  - jboss-eap5and6to7-xml-18000
+  - jboss-eap5and6to7-xml-31000
+  - jboss-eap5and6to7-xml-31500
+  - jboss-eap5and6to7-xml-32000
+  - jboss-eap5and6to7-xml-33000
+  - jboss-eap5and6to7-xml-34000
+  - jboss-eap5and6to7-xml-37000
+  - jboss-eap5and6to7-xml-38000
+  - jboss-eap5and6to7-xml-38001
+  - jboss-eap5and6to7-xml-38002
+  - jboss-eap5and6to7-xml-38003
+  - jboss-eap5and6to7-xml-38004
+  - jboss-eap5and6to7-xml-38005
+  - jboss-eap5and6to7-xml-38006
+  - jboss-eap5and6to7-xml-38007
+  - jboss-eap5and6to7-xml-39000
+  - jboss-eap5and6to7-xml-40000
+  - maven-artemis-jms-client-00001
+  - maven-jboss-rmi-api_1.0_spec-00001
+  - microprofile_removed_from_eap-00001
+  - microprofile_removed_from_eap-00001-01
+  - microprofile_removed_from_eap-00002
+  - microprofile_removed_from_eap-00003
+  - microprofile_removed_from_eap-00004
+  - move-to-microprofile-rest-client-1.3-00001
+  - picketlink25-00000
+  - resteasy-eap5and6to7-000018
+  - resteasy-eap6-000001
+  - resteasy-eap6-000002
+  - resteasy-eap6-000003
+  - resteasy-eap6-000004
+  - resteasy-eap6-000005
+  - resteasy-eap6-000006
+  - resteasy-eap6-000007
+  - resteasy-eap6-000008
+  - resteasy-eap6-000009
+  - resteasy-eap6-000010
+  - resteasy-eap6-000011
+  - resteasy-eap6-000012
+  - resteasy-eap6-000013
+  - resteasy-eap6-000014
+  - resteasy-eap6-000015
+  - resteasy-eap6-000017
+  - resteasy-eap6-000019
+  - resteasy-eap6-000020
+  - resteasy-eap6-000021
+  - resteasy-eap6-000022
+  - resteasy-eap6-000023
+  - resteasy-eap6-000024
+  - resteasy-eap6-000025
+  - resteasy-eap6-000029
+  - resteasy-eap6-000030
+  - resteasy-eap6-000032
+  - resteasy-eap6-000101
+  - resteasy-eap6-000103
+  - resteasy-eap6-000104
+  - resteasy-eap6-000105
+  - resteasy-eap6-000106
+  - resteasy-eap6-000107
+  - resteasy-eap6-000118
+  - resteasy-eap6-000119
+  - resteasy-eap6-000120
+  - resteasy-eap6-000121
+  - resteasy-eap6-000122
+  - resteasy-eap6-000123
+  - resteasy-eap6-000125
+  - resteasy-eap6-000126
+  - resteasy-eap6-000127
+  - resteasy-eap6-000128
+  - resteasy-eap6-000129
+  - resteasy-eap6-000130
+  - resteasy-eap6-000131
+  - resteasy-eap6-000140
+  - resteasy-eap6-000141
+  - resteasy-eap6-000142
+  - resteasy30-36-00001
+  - singleton-sessionbean-00001
+  - weblogic-catchall-01000
+  - weblogic-catchall-02000
+  - weblogic-catchall-03000
+  - weblogic-catchall-06000
+  - weblogic-catchall-06500
+  - weblogic-eap7-01000
+  - weblogic-eap7-016000
+  - weblogic-eap7-017000
+  - weblogic-eap7-02000
+  - weblogic-eap7-03000
+  - weblogic-eap7-04000
+  - weblogic-eap7-05000
+  - weblogic-eap7-06000
+  - weblogic-eap7-07000
+  - weblogic-eap7-08000
+  - weblogic-eap7-09000
+  - weblogic-eap7-10000
+  - weblogic-eap7-11000
+  - weblogic-eap7-12000
+  - weblogic-eap7-13000
+  - weblogic-eap7-15000
+  - weblogic-ejb-01000
+  - weblogic-ejb-02000
+  - weblogic-ejb-03000
+  - weblogic-ejb-04000
+  - weblogic-jms-eap7-00000
+  - weblogic-jms-eap7-01000
+  - weblogic-jms-eap7-02000
+  - weblogic-jms-eap7-03000
+  - weblogic-jms-eap7-04000
+  - weblogic-jms-eap7-05000
+  - weblogic-jms-eap7-06000
+  - weblogic-jms-eap7-07000
+  - weblogic-jms-eap7-08000
+  - weblogic-services-eap7-01000
+  - weblogic-services-eap7-02000
+  - weblogic-services-eap7-03000
+  - weblogic-webapp-eap7-01000
+  - weblogic-webapp-eap7-02000
+  - weblogic-webapp-eap7-03000
+  - weblogic-webapp-eap7-04000
+  - weblogic-webapp-eap7-05000
+  - weblogic-webapp-eap7-06000
+  - weblogic-webapp-eap7-07000
+  - weblogic-webapp-eap7-08000
+  - weblogic-webapp-eap7-09000
+  - weblogic-webservices-07000
+  - weblogic-webservices-eap7-01000
+  - weblogic-webservices-eap7-02000
+  - weblogic-webservices-eap7-03000
+  - weblogic-webservices-eap7-04000
+  - weblogic-webservices-eap7-05000
+  - weblogic-webservices-eap7-06000
+  - weblogic-xml-descriptor-19000
+  - weblogic-xml-descriptor-eap7-01000
+  - weblogic-xml-descriptor-eap7-02000
+  - weblogic-xml-descriptor-eap7-03000
+  - weblogic-xml-descriptor-eap7-04000
+  - weblogic-xml-descriptor-eap7-06001
+  - weblogic-xml-descriptor-eap7-07000
+  - weblogic-xml-descriptor-eap7-08000
+  - weblogic-xml-descriptor-eap7-09000
+  - weblogic-xml-descriptor-eap7-10000
+  - weblogic-xml-descriptor-eap7-11000
+  - weblogic-xml-descriptor-eap7-12000
+  - weblogic-xml-descriptor-eap7-13000
+  - weblogic-xml-descriptor-eap7-14000
+  - weblogic-xml-descriptor-eap7-15000
+  - weblogic-xml-descriptor-eap7-16000
+  - weblogic-xml-descriptor-eap7-17000
+  - weblogic-xml-descriptor-eap7-18000
+  - websphere-catchall-00000
+  - websphere-catchall-00001
+  - websphere-catchall-db2-00000
+  - websphere-jms-eap7-00000
+  - websphere-jms-eap7-01000
+  - websphere-jms-eap7-02000
+  - websphere-jms-eap7-02500
+  - websphere-jms-eap7-03000
+  - websphere-jms-eap7-04000
+  - websphere-mq-eap7-00000
+  - websphere-mq-eap7-01000
+  - websphere-mq-eap7-02000
+  - websphere-mqe-eap7-00000
+  - websphere-mqe-eap7-01000
+  - websphere-mqe-eap7-02000
+  - websphere-mqe-eap7-03000
+  - websphere-mqe-eap7-04000
+  - websphere-other-eap7-01000
+  - websphere-other-eap7-02000
+  - ws-security-00000
+  - ws-security-00001
+  - ws-security-00002
+- name: eap8/eap7
+  description: This ruleset provides analysis of Java EE applications that need to change certain CDI-related method calls.
+  violations:
+    javax-to-jakarta-dependencies-00004:
+      description: javax.activation groupId has been replaced by jakarta.activation
+      category: mandatory
+      labels:
+      - konveyor.io/source
+      - konveyor.io/target=eap
+      - konveyor.io/target=eap8
+      - konveyor.io/target=jakarta-ee
+      - konveyor.io/target=jakarta-ee9+
+      - konveyor.io/target=jws
+      - konveyor.io/target=jws6+
+      incidents:
+      - uri: file:///shared/source/tackle-testapp/pom.xml
+        message: Replace dependency groupId `javax.activation` with `jakarta.activation`
+        codeSnip: " 90  \t\t\t<version>2.5.0</version>\n 91  \t\t</dependency>\n 92  \t\t<dependency>\n 93  \t\t\t<groupId>org.apache.tomcat</groupId>\n 94  \t\t\t<artifactId>tomcat-jdbc</artifactId>\n 95  \t\t\t<version>${tomcat.version}</version>\n 96  \t\t\t<scope>runtime</scope>\n 97  \t\t</dependency>\n 98  \t\t<dependency>\n 99  \t\t\t<groupId>org.hibernate</groupId>\n100  \t\t\t<artifactId>hibernate-entitymanager</artifactId>\n101  \t\t\t<version>${hibernate.version}</version>\n102  \t\t</dependency>\n103  \t\t<dependency>\n104  \t\t\t<groupId>org.hibernate.validator</groupId>\n105  \t\t\t<artifactId>hibernate-validator</artifactId>\n106  \t\t\t<version>${hibernate-validator.version}</version>\n107  \t\t</dependency>\n108  \t\t<dependency>\n109  \t\t\t<groupId>ch.qos.logback</groupId>\n110  \t\t\t<artifactId>logback-classic</artifactId>"
+        lineNumber: 99
+        variables:
+          name: javax.activation.javax.activation-api
+          version: 1.2.0
+      links:
+      - url: https://jakarta.ee/
+        title: Jakarta EE
+      effort: 1
+    javax-to-jakarta-import-00001:
+      description: The package 'javax' has been replaced by 'jakarta'.
+      category: mandatory
+      labels:
+      - konveyor.io/source
+      - konveyor.io/target=eap
+      - konveyor.io/target=eap8
+      - konveyor.io/target=jakarta-ee
+      - konveyor.io/target=jakarta-ee9+
+      - konveyor.io/target=jws
+      - konveyor.io/target=jws6+
+      incidents:
+      - uri: file:///shared/source/tackle-testapp/src/main/java/io/konveyor/demo/ordermanagement/OrderManagementAppInitializer.java
+        message: Replace the `javax.servlet` import statement with `jakarta.servlet`
+        codeSnip: " 1  package io.konveyor.demo.ordermanagement;\n 2  \n 3  import javax.servlet.ServletContext;\n 4  import javax.servlet.ServletException;\n 5  import javax.servlet.ServletRegistration;\n 6  \n 7  import org.springframework.web.WebApplicationInitializer;\n 8  import org.springframework.web.context.ContextLoaderListener;\n 9  import org.springframework.web.context.support.AnnotationConfigWebApplicationContext;\n10  import org.springframework.web.servlet.DispatcherServlet;\n11  \n12  public class OrderManagementAppInitializer implements WebApplicationInitializer  {\n13  "
+        lineNumber: 3
+        variables:
+          file: file:///shared/source/tackle-testapp/src/main/java/io/konveyor/demo/ordermanagement/OrderManagementAppInitializer.java
+          kind: Module
+          name: javax.servlet.ServletContext
+          package: io.konveyor.demo.ordermanagement
+          renamed: servlet
+      - uri: file:///shared/source/tackle-testapp/src/main/java/io/konveyor/demo/ordermanagement/OrderManagementAppInitializer.java
+        message: Replace the `javax.servlet` import statement with `jakarta.servlet`
+        codeSnip: " 1  package io.konveyor.demo.ordermanagement;\n 2  \n 3  import javax.servlet.ServletContext;\n 4  import javax.servlet.ServletException;\n 5  import javax.servlet.ServletRegistration;\n 6  \n 7  import org.springframework.web.WebApplicationInitializer;\n 8  import org.springframework.web.context.ContextLoaderListener;\n 9  import org.springframework.web.context.support.AnnotationConfigWebApplicationContext;\n10  import org.springframework.web.servlet.DispatcherServlet;\n11  \n12  public class OrderManagementAppInitializer implements WebApplicationInitializer  {\n13  \n14  \t@Override"
+        lineNumber: 4
+        variables:
+          file: file:///shared/source/tackle-testapp/src/main/java/io/konveyor/demo/ordermanagement/OrderManagementAppInitializer.java
+          kind: Module
+          name: javax.servlet.ServletException
+          package: io.konveyor.demo.ordermanagement
+          renamed: servlet
+      - uri: file:///shared/source/tackle-testapp/src/main/java/io/konveyor/demo/ordermanagement/OrderManagementAppInitializer.java
+        message: Replace the `javax.servlet` import statement with `jakarta.servlet`
+        codeSnip: " 1  package io.konveyor.demo.ordermanagement;\n 2  \n 3  import javax.servlet.ServletContext;\n 4  import javax.servlet.ServletException;\n 5  import javax.servlet.ServletRegistration;\n 6  \n 7  import org.springframework.web.WebApplicationInitializer;\n 8  import org.springframework.web.context.ContextLoaderListener;\n 9  import org.springframework.web.context.support.AnnotationConfigWebApplicationContext;\n10  import org.springframework.web.servlet.DispatcherServlet;\n11  \n12  public class OrderManagementAppInitializer implements WebApplicationInitializer  {\n13  \n14  \t@Override\n15  \tpublic void onStartup(ServletContext container) throws ServletException {"
+        lineNumber: 5
+        variables:
+          file: file:///shared/source/tackle-testapp/src/main/java/io/konveyor/demo/ordermanagement/OrderManagementAppInitializer.java
+          kind: Module
+          name: javax.servlet.ServletRegistration
+          package: io.konveyor.demo.ordermanagement
+          renamed: servlet
+      - uri: file:///shared/source/tackle-testapp/src/main/java/io/konveyor/demo/ordermanagement/model/Customer.java
+        message: Replace the `javax.persistence` import statement with `jakarta.persistence`
+        codeSnip: " 1  package io.konveyor.demo.ordermanagement.model;\n 2  \n 3  import javax.persistence.Column;\n 4  import javax.persistence.Entity;\n 5  import javax.persistence.GeneratedValue;\n 6  import javax.persistence.GenerationType;\n 7  import javax.persistence.Id;\n 8  import javax.persistence.SequenceGenerator;\n 9  import javax.persistence.Table;\n10  \n11  @Entity\n12  @Table(name = \"customers\")\n13  public class Customer {"
+        lineNumber: 3
+        variables:
+          file: file:///shared/source/tackle-testapp/src/main/java/io/konveyor/demo/ordermanagement/model/Customer.java
+          kind: Module
+          name: javax.persistence.Column
+          package: io.konveyor.demo.ordermanagement.model
+          renamed: persistence
+      - uri: file:///shared/source/tackle-testapp/src/main/java/io/konveyor/demo/ordermanagement/model/Customer.java
+        message: Replace the `javax.persistence` import statement with `jakarta.persistence`
+        codeSnip: " 1  package io.konveyor.demo.ordermanagement.model;\n 2  \n 3  import javax.persistence.Column;\n 4  import javax.persistence.Entity;\n 5  import javax.persistence.GeneratedValue;\n 6  import javax.persistence.GenerationType;\n 7  import javax.persistence.Id;\n 8  import javax.persistence.SequenceGenerator;\n 9  import javax.persistence.Table;\n10  \n11  @Entity\n12  @Table(name = \"customers\")\n13  public class Customer {\n14  \t@Id"
+        lineNumber: 4
+        variables:
+          file: file:///shared/source/tackle-testapp/src/main/java/io/konveyor/demo/ordermanagement/model/Customer.java
+          kind: Module
+          name: javax.persistence.Entity
+          package: io.konveyor.demo.ordermanagement.model
+          renamed: persistence
+      - uri: file:///shared/source/tackle-testapp/src/main/java/io/konveyor/demo/ordermanagement/model/Customer.java
+        message: Replace the `javax.persistence` import statement with `jakarta.persistence`
+        codeSnip: " 1  package io.konveyor.demo.ordermanagement.model;\n 2  \n 3  import javax.persistence.Column;\n 4  import javax.persistence.Entity;\n 5  import javax.persistence.GeneratedValue;\n 6  import javax.persistence.GenerationType;\n 7  import javax.persistence.Id;\n 8  import javax.persistence.SequenceGenerator;\n 9  import javax.persistence.Table;\n10  \n11  @Entity\n12  @Table(name = \"customers\")\n13  public class Customer {\n14  \t@Id\n15      @SequenceGenerator("
+        lineNumber: 5
+        variables:
+          file: file:///shared/source/tackle-testapp/src/main/java/io/konveyor/demo/ordermanagement/model/Customer.java
+          kind: Module
+          name: javax.persistence.GeneratedValue
+          package: io.konveyor.demo.ordermanagement.model
+          renamed: persistence
+      - uri: file:///shared/source/tackle-testapp/src/main/java/io/konveyor/demo/ordermanagement/model/Customer.java
+        message: Replace the `javax.persistence` import statement with `jakarta.persistence`
+        codeSnip: " 1  package io.konveyor.demo.ordermanagement.model;\n 2  \n 3  import javax.persistence.Column;\n 4  import javax.persistence.Entity;\n 5  import javax.persistence.GeneratedValue;\n 6  import javax.persistence.GenerationType;\n 7  import javax.persistence.Id;\n 8  import javax.persistence.SequenceGenerator;\n 9  import javax.persistence.Table;\n10  \n11  @Entity\n12  @Table(name = \"customers\")\n13  public class Customer {\n14  \t@Id\n15      @SequenceGenerator(\n16              name = \"customersSequence\","
+        lineNumber: 6
+        variables:
+          file: file:///shared/source/tackle-testapp/src/main/java/io/konveyor/demo/ordermanagement/model/Customer.java
+          kind: Module
+          name: javax.persistence.GenerationType
+          package: io.konveyor.demo.ordermanagement.model
+          renamed: persistence
+      - uri: file:///shared/source/tackle-testapp/src/main/java/io/konveyor/demo/ordermanagement/model/Customer.java
+        message: Replace the `javax.persistence` import statement with `jakarta.persistence`
+        codeSnip: " 1  package io.konveyor.demo.ordermanagement.model;\n 2  \n 3  import javax.persistence.Column;\n 4  import javax.persistence.Entity;\n 5  import javax.persistence.GeneratedValue;\n 6  import javax.persistence.GenerationType;\n 7  import javax.persistence.Id;\n 8  import javax.persistence.SequenceGenerator;\n 9  import javax.persistence.Table;\n10  \n11  @Entity\n12  @Table(name = \"customers\")\n13  public class Customer {\n14  \t@Id\n15      @SequenceGenerator(\n16              name = \"customersSequence\",\n17              sequenceName = \"customers_id_seq\","
+        lineNumber: 7
+        variables:
+          file: file:///shared/source/tackle-testapp/src/main/java/io/konveyor/demo/ordermanagement/model/Customer.java
+          kind: Module
+          name: javax.persistence.Id
+          package: io.konveyor.demo.ordermanagement.model
+          renamed: persistence
+      - uri: file:///shared/source/tackle-testapp/src/main/java/io/konveyor/demo/ordermanagement/model/Customer.java
+        message: Replace the `javax.persistence` import statement with `jakarta.persistence`
+        codeSnip: " 1  package io.konveyor.demo.ordermanagement.model;\n 2  \n 3  import javax.persistence.Column;\n 4  import javax.persistence.Entity;\n 5  import javax.persistence.GeneratedValue;\n 6  import javax.persistence.GenerationType;\n 7  import javax.persistence.Id;\n 8  import javax.persistence.SequenceGenerator;\n 9  import javax.persistence.Table;\n10  \n11  @Entity\n12  @Table(name = \"customers\")\n13  public class Customer {\n14  \t@Id\n15      @SequenceGenerator(\n16              name = \"customersSequence\",\n17              sequenceName = \"customers_id_seq\",\n18              allocationSize = 1,"
+        lineNumber: 8
+        variables:
+          file: file:///shared/source/tackle-testapp/src/main/java/io/konveyor/demo/ordermanagement/model/Customer.java
+          kind: Module
+          name: javax.persistence.SequenceGenerator
+          package: io.konveyor.demo.ordermanagement.model
+          renamed: persistence
+      - uri: file:///shared/source/tackle-testapp/src/main/java/io/konveyor/demo/ordermanagement/model/Customer.java
+        message: Replace the `javax.persistence` import statement with `jakarta.persistence`
+        codeSnip: " 1  package io.konveyor.demo.ordermanagement.model;\n 2  \n 3  import javax.persistence.Column;\n 4  import javax.persistence.Entity;\n 5  import javax.persistence.GeneratedValue;\n 6  import javax.persistence.GenerationType;\n 7  import javax.persistence.Id;\n 8  import javax.persistence.SequenceGenerator;\n 9  import javax.persistence.Table;\n10  \n11  @Entity\n12  @Table(name = \"customers\")\n13  public class Customer {\n14  \t@Id\n15      @SequenceGenerator(\n16              name = \"customersSequence\",\n17              sequenceName = \"customers_id_seq\",\n18              allocationSize = 1,\n19              initialValue = 6)"
+        lineNumber: 9
+        variables:
+          file: file:///shared/source/tackle-testapp/src/main/java/io/konveyor/demo/ordermanagement/model/Customer.java
+          kind: Module
+          name: javax.persistence.Table
+          package: io.konveyor.demo.ordermanagement.model
+          renamed: persistence
+      effort: 1
+  unmatched:
+  - javaee-to-jakarta-namespaces-00001
+  - javaee-to-jakarta-namespaces-00002
+  - javaee-to-jakarta-namespaces-00003
+  - javaee-to-jakarta-namespaces-00004
+  - javaee-to-jakarta-namespaces-00005
+  - javaee-to-jakarta-namespaces-00006
+  - javaee-to-jakarta-namespaces-00007
+  - javaee-to-jakarta-namespaces-00008
+  - javaee-to-jakarta-namespaces-00009
+  - javaee-to-jakarta-namespaces-00010
+  - javaee-to-jakarta-namespaces-00011
+  - javaee-to-jakarta-namespaces-00012
+  - javaee-to-jakarta-namespaces-00013
+  - javaee-to-jakarta-namespaces-00014
+  - javaee-to-jakarta-namespaces-00015
+  - javaee-to-jakarta-namespaces-00016
+  - javaee-to-jakarta-namespaces-00017
+  - javaee-to-jakarta-namespaces-00018
+  - javaee-to-jakarta-namespaces-00019
+  - javaee-to-jakarta-namespaces-00020
+  - javaee-to-jakarta-namespaces-00021
+  - javaee-to-jakarta-namespaces-00022
+  - javaee-to-jakarta-namespaces-00023
+  - javaee-to-jakarta-namespaces-00024
+  - javaee-to-jakarta-namespaces-00025
+  - javaee-to-jakarta-namespaces-00026
+  - javaee-to-jakarta-namespaces-00027
+  - javaee-to-jakarta-namespaces-00028
+  - javaee-to-jakarta-namespaces-00029
+  - javaee-to-jakarta-namespaces-00030
+  - javaee-to-jakarta-namespaces-00031
+  - javaee-to-jakarta-namespaces-00032
+  - javaee-to-jakarta-namespaces-00033
+  - javaee-to-jakarta-namespaces-00034
+  - javaee-to-jakarta-namespaces-00035
+  - javaee-to-jakarta-namespaces-00036
+  - javaee-to-jakarta-namespaces-00037
+  - javaee-to-jakarta-namespaces-00038
+  - javaee-to-jakarta-namespaces-00039
+  - javaee-to-jakarta-namespaces-00040
+  - javaee-to-jakarta-namespaces-00041
+  - javaee-to-jakarta-namespaces-00042
+  - javaee-to-jakarta-namespaces-00043
+  - javaee-to-jakarta-namespaces-00044
+  - javaee-to-jakarta-namespaces-00045
+  - javaee-to-jakarta-namespaces-00046
+  - javaee-to-jakarta-namespaces-00047
+  - javaee-to-jakarta-namespaces-00048
+  - javaee-to-jakarta-namespaces-00049
+  - javaee-to-jakarta-namespaces-00050
+  - javaee-to-jakarta-namespaces-00051
+  - javaee-to-jakarta-namespaces-00052
+  - javaee-to-jakarta-namespaces-00053
+  - javaee-to-jakarta-namespaces-00054
+  - javaee-to-jakarta-namespaces-00055
+  - javaee-to-jakarta-namespaces-00056
+  - javax-to-jakarta-bootstrapping-files-00001
+  - javax-to-jakarta-dependencies-00001
+  - javax-to-jakarta-dependencies-00002
+  - javax-to-jakarta-dependencies-00003
+  - javax-to-jakarta-dependencies-00005
+  - javax-to-jakarta-dependencies-00006
+  - javax-to-jakarta-dependencies-00007
+  - javax-to-jakarta-dependencies-00008
+  - javax-to-jakarta-properties-00001
+  - javax-to-jakarta-servlet-00010
+  - javax-to-jakarta-servlet-00020
+  - javax-to-jakarta-servlet-00030
+  - javax-to-jakarta-servlet-00040
+  - javax-to-jakarta-servlet-00041
+  - javax-to-jakarta-servlet-00042
+  - javax-to-jakarta-servlet-00043
+  - javax-to-jakarta-servlet-00050
+  - javax-to-jakarta-servlet-00060
+  - javax-to-jakarta-servlet-00070
+  - javax-to-jakarta-servlet-00071
+  - javax-to-jakarta-servlet-00072
+  - javax-to-jakarta-servlet-00080
+  - javax-to-jakarta-servlet-00090
+  - javax-to-jakarta-servlet-00100
+  - javax-to-jakarta-servlet-00101
+  - javax-to-jakarta-servlet-00102
+  - javax-to-jakarta-servlet-00110
+  - javax-to-jakarta-servlet-00111
+  - javax-to-jakarta-servlet-00112
+  - javax-to-jakarta-servlet-00120
+  - javax-to-jakarta-servlet-00121
+  - javax-to-jakarta-servlet-00122
+  - javax-to-jakarta-servlet-00123
+  - javax-to-jakarta-servlet-00130
+  skipped:
+  - deprecated-initialcontextfactory-is-removed-00001
+  - eap8-ejb-00001
+  - eap8-ejb-00002
+  - eap8-ejb-00003
+  - eap8-faces-00001
+  - eap8-faces-00002
+  - eap8-faces-00003
+  - eap8-faces-00004
+  - eap8-faces-00005
+  - eap8-faces-00006
+  - eap8-faces-00007
+  - eap8-faces-00008
+  - eap8-faces-00009
+  - eap8-resteasy-00001
+  - eap8-resteasy-00002
+  - eap8-resteasy-00003
+  - eap8-resteasy-00004
+  - eap8-resteasy-00005
+  - eap8-resteasy-00006
+  - eap8-resteasy-00007
+  - eap8-resteasy-00008
+  - eap8-resteasy-00009
+  - eap8-resteasy-00010
+  - eap8-resteasy-00011
+  - eap8-xml-binding-00001
+  - eap8-xml-binding-00002
+  - eap8-xml-binding-00003
+  - eap8-xml-binding-00004
+  - eap8-xml-binding-00005
+  - eap8-xml-binding-00006
+  - eap8-xml-binding-00007
+  - eap8-xml-binding-00008
+  - eap8-xml-binding-00009
+  - empty-beans-xml-00001
+  - hibernate-00005
+  - hibernate-00010
+  - hibernate-6.2-00010
+  - hibernate-6.2-00020
+  - hibernate-6.2-00030
+  - hibernate-6.2-00040
+  - hibernate-6.2-00050
+  - hibernate-search-00010
+  - hibernate-search-00020
+  - hibernate-search-00030
+  - hibernate-search-00040
+  - hibernate-search-00050
+  - hibernate-search-00060
+  - hibernate-search-00070
+  - hibernate-search-00080
+  - hibernate-search-00090
+  - hibernate-search-00100
+  - hibernate-search-00105
+  - hibernate-search-00110
+  - hibernate-search-00120
+  - hibernate-search-00140
+  - hibernate-search-00150
+  - hibernate-search-00160
+  - hibernate-search-00170
+  - hibernate-search-00180
+  - hibernate-search-00190
+  - hibernate-search-00200
+  - hibernate-search-00210
+  - hibernate-search-00220
+  - hibernate-search-00230
+  - hibernate-search-00240
+  - hibernate-search-00250
+  - hibernate-search-00260
+  - hibernate-search-00270
+  - hibernate-search-00280
+  - hibernate-search-00290
+  - hibernate-search-00300
+  - hibernate-search-00310
+  - hibernate-search-00320
+  - hibernate-search-00330
+  - hibernate-search-00340
+  - hibernate-search-00350
+  - hibernate-search-00360
+  - hibernate-search-00370
+  - hibernate-search-00380
+  - hibernate-search-00390
+  - hibernate-search-00400
+  - hibernate-search-00410
+  - hibernate-search-00420
+  - hibernate-search-00430
+  - hibernate-search-00440
+  - hibernate-search-00450
+  - hibernate-search-00460
+  - hibernate-search-00470
+  - hibernate-search-00480
+  - hibernate-search-00490
+  - hibernate-search-00500
+  - hibernate-search-00510
+  - hibernate-search-00520
+  - hibernate-search-00530
+  - hibernate-search-00540
+  - hibernate-search-00550
+  - hibernate-search-00560
+  - hibernate-search-00570
+  - hibernate-search-00580
+  - hibernate-search-00590
+  - hibernate-search-00600
+  - hibernate-search-00610
+  - hibernate-search-00620
+  - hibernate-search-00630
+  - hibernate-search-00640
+  - hibernate-search-00650
+  - hibernate-search-00660
+  - hibernate-search-00670
+  - hibernate-search-00680
+  - hibernate-search-00690
+  - hibernate-search-00700
+  - hibernate-search-00710
+  - hibernate-search-00720
+  - hibernate-search-00730
+  - hibernate-search-00740
+  - hibernate-search-00750
+  - hibernate-search-00760
+  - hibernate-search-00770
+  - hibernate-search-00780
+  - hibernate-search-00790
+  - hibernate-search-00800
+  - hibernate-search-00810
+  - hibernate-search-00820
+  - hibernate-search-00830
+  - hibernate-search-00840
+  - hibernate-search-00850
+  - hibernate-search-00860
+  - hibernate-search-00870
+  - hibernate-search-00880
+  - hibernate-search-00890
+  - hibernate-search-00900
+  - hibernate-search-00910
+  - hibernate-search-00920
+  - hibernate-search-00930
+  - hibernate-search-00940
+  - hibernate-search-00950
+  - hibernate-search-00960
+  - hibernate-search-00970
+  - hibernate-search-00980
+  - hibernate-search-00990
+  - hibernate-search-01000
+  - hibernate-search-01010
+  - hibernate-search-01020
+  - hibernate-search-01030
+  - hibernate-search-01040
+  - hibernate-search-6.1-00010
+  - hibernate-search-6.1-00020
+  - hibernate-search-6.1-00030
+  - hibernate-search-6.1-00040
+  - hibernate-search-6.1-00050
+  - hibernate-search-6.1-00060
+  - hibernate-search-6.1-00070
+  - hibernate-search-6.1-00080
+  - hibernate-search-6.1-00090
+  - hibernate-search-6.1-00100
+  - hibernate-search-6.1-00120
+  - hibernate-search-6.1-00130
+  - hibernate-search-6.1-00140
+  - hibernate-search-6.1-00150
+  - hibernate-search-6.1-00160
+  - hibernate-search-6.1-00170
+  - hibernate-search-6.1-00180
+  - hibernate-search-6.1-00190
+  - hibernate6-00020
+  - hibernate6-00030
+  - hibernate6-00040
+  - hibernate6-00050
+  - hibernate6-00060
+  - hibernate6-00070
+  - hibernate6-00080
+  - hibernate6-00090
+  - hibernate6-00100
+  - hibernate6-00110
+  - hibernate6-00120
+  - hibernate6-00130
+  - hibernate6-00140
+  - hibernate6-00150
+  - hibernate6-00160
+  - hibernate6-00170
+  - hibernate6-00180
+  - hibernate6-00190
+  - hibernate6-00200
+  - hibernate6-00210
+  - hibernate6-00220
+  - hibernate6-00230
+  - hibernate6-00240
+  - hibernate6-00250
+  - hibernate6-00251
+  - hibernate6-00252
+  - hibernate6-00253
+  - hibernate6-00254
+  - hibernate6-00255
+  - hibernate6-00257
+  - hibernate6-00270
+  - hibernate6-00280
+  - jakarta-cdi-00001
+  - jakarta-cdi-00002
+  - jakarta-cdi-00003
+  - jakarta-cdi-00004
+  - jakarta-el-00010
+  - jakarta-el-00020
+  - jakarta-faces-00001
+  - jakarta-json-binding-00010
+  - jakarta-soap-00010
+  - jakarta-soap-00020
+  - jakarta-ws-rs-00001
+  - jboss-dependencies-00001
+  - jboss-dependencies-00002
+  - jboss-dependencies-00003
+  - jboss-dependencies-00004
+  - jboss-dependencies-00005
+  - jboss-dependencies-00006
+  - jboss-dependencies-00007
+  - jboss-dependencies-00008
+  - jboss-dependencies-00009
+  - jboss-dependencies-00010
+  - jboss-dependencies-00011
+  - jboss-dependencies-00012
+  - jboss-dependencies-00013
+  - jboss-dependencies-00014
+  - jboss-dependencies-00015
+  - jboss-dependencies-00016
+  - jboss-dependencies-00017
+  - jboss-dependencies-00018
+  - jboss-dependencies-00019
+  - jboss-dependencies-00020
+  - jboss-dependencies-00021
+  - jboss-dependencies-00022
+  - jboss-dependencies-00023
+  - jboss-dependencies-00024
+  - jboss-dependencies-00025
+  - jboss-dependencies-00026
+  - jboss-dependencies-00027
+  - jboss-dependencies-00028
+  - jboss-dependencies-00030
+  - jboss-dependencies-00031
+  - jboss-dependencies-00032
+  - keycloak-openid-00001
+  - keycloak-openid-00010
+  - legacy-vault-00010
+  - log4j-removed-00001
+  - log4j-removed-00002
+  - log4j-removed-00003
+  - log4j-removed-00004
+  - log4j-removed-00005
+  - login-modules-00001
+  - picketlink-00010
+  - picketlink-00020
+- name: jakarta-ee9
+  violations:
+    spring-components-00001:
+      description: Version of Spring Boot not compatible with Jakarta EE 9+
+      category: mandatory
+      labels:
+      - konveyor.io/source
+      - konveyor.io/target=jakarta-ee
+      - konveyor.io/target=jakarta-ee9+
+      - konveyor.io/target=jws
+      - konveyor.io/target=jws6+
+      incidents:
+      - uri: file:///shared/source/tackle-testapp/pom.xml
+        message: Version 3.0.0 is the minimum version of Spring Boot that is Jakarta EE 9+ compatible
+        codeSnip: "79  \t\t\t<artifactId>spring-webmvc</artifactId>\n80  \t\t\t<version>${spring-framework.version}</version>\n81  \t\t</dependency>\n82  \t\t<dependency>\n83  \t\t\t<groupId>org.springframework</groupId>\n84  \t\t\t<artifactId>spring-web</artifactId>\n85  \t\t\t<version>${spring-framework.version}</version>\n86  \t\t</dependency>\n87  \t\t<dependency>\n88  \t\t\t<groupId>org.springframework.boot</groupId>\n89  \t\t\t<artifactId>spring-boot-starter-actuator</artifactId>\n90  \t\t\t<version>2.5.0</version>\n91  \t\t</dependency>\n92  \t\t<dependency>\n93  \t\t\t<groupId>org.apache.tomcat</groupId>\n94  \t\t\t<artifactId>tomcat-jdbc</artifactId>\n95  \t\t\t<version>${tomcat.version}</version>\n96  \t\t\t<scope>runtime</scope>\n97  \t\t</dependency>\n98  \t\t<dependency>\n99  \t\t\t<groupId>org.hibernate</groupId>"
+        lineNumber: 88
+        variables:
+          name: org.springframework.boot.spring-boot-starter-actuator
+          version: 2.5.0
+      links:
+      - url: https://spring.io/blog/2021/09/02/a-java-17-and-jakarta-ee-9-baseline-for-spring-framework-6/
+        title: A Java 17 and Jakarta EE 9 baseline for Spring Framework 6
+      effort: 3
+    spring-components-00002:
+      description: Version of Spring not compatible with Jakarta EE 9+
+      category: mandatory
+      labels:
+      - konveyor.io/source
+      - konveyor.io/target=jakarta-ee
+      - konveyor.io/target=jakarta-ee9+
+      - konveyor.io/target=jws
+      - konveyor.io/target=jws6+
+      incidents:
+      - uri: file:///shared/source/tackle-testapp/pom.xml
+        message: Version 6.0.0 is the minimum version of Spring that is Jakarta EE 9+ compatible
+        codeSnip: "59  \t\t<dependency>\n60  \t\t\t<groupId>com.fasterxml.jackson.core</groupId>\n61  \t\t\t<artifactId>jackson-core</artifactId>\n62  \t\t</dependency>\n63  \t\t<dependency>\n64  \t\t\t<groupId>com.fasterxml.jackson.core</groupId>\n65  \t\t\t<artifactId>jackson-databind</artifactId>\n66  \t\t</dependency>\n67  \t\t<dependency>\n68  \t\t\t<groupId>org.springframework.data</groupId>\n69  \t\t\t<artifactId>spring-data-jpa</artifactId>\n70  \t\t</dependency>\n71  \n72  \t\t<dependency>\n73  \t\t\t<groupId>org.springframework</groupId>\n74  \t\t\t<artifactId>spring-jdbc</artifactId>\n75  \t\t\t<version>${spring-framework.version}</version>\n76  \t\t</dependency>\n77  \t\t<dependency>\n78  \t\t\t<groupId>org.springframework</groupId>\n79  \t\t\t<artifactId>spring-webmvc</artifactId>"
+        lineNumber: 68
+        variables:
+          name: org.springframework.data.spring-data-jpa
+          version: 2.5.1
+      - uri: file:///shared/source/tackle-testapp/pom.xml
+        message: Version 6.0.0 is the minimum version of Spring that is Jakarta EE 9+ compatible
+        codeSnip: "64  \t\t\t<groupId>com.fasterxml.jackson.core</groupId>\n65  \t\t\t<artifactId>jackson-databind</artifactId>\n66  \t\t</dependency>\n67  \t\t<dependency>\n68  \t\t\t<groupId>org.springframework.data</groupId>\n69  \t\t\t<artifactId>spring-data-jpa</artifactId>\n70  \t\t</dependency>\n71  \n72  \t\t<dependency>\n73  \t\t\t<groupId>org.springframework</groupId>\n74  \t\t\t<artifactId>spring-jdbc</artifactId>\n75  \t\t\t<version>${spring-framework.version}</version>\n76  \t\t</dependency>\n77  \t\t<dependency>\n78  \t\t\t<groupId>org.springframework</groupId>\n79  \t\t\t<artifactId>spring-webmvc</artifactId>\n80  \t\t\t<version>${spring-framework.version}</version>\n81  \t\t</dependency>\n82  \t\t<dependency>\n83  \t\t\t<groupId>org.springframework</groupId>\n84  \t\t\t<artifactId>spring-web</artifactId>"
+        lineNumber: 73
+        variables:
+          name: org.springframework.spring-jdbc
+          version: 5.3.7
+      - uri: file:///shared/source/tackle-testapp/pom.xml
+        message: Version 6.0.0 is the minimum version of Spring that is Jakarta EE 9+ compatible
+        codeSnip: "69  \t\t\t<artifactId>spring-data-jpa</artifactId>\n70  \t\t</dependency>\n71  \n72  \t\t<dependency>\n73  \t\t\t<groupId>org.springframework</groupId>\n74  \t\t\t<artifactId>spring-jdbc</artifactId>\n75  \t\t\t<version>${spring-framework.version}</version>\n76  \t\t</dependency>\n77  \t\t<dependency>\n78  \t\t\t<groupId>org.springframework</groupId>\n79  \t\t\t<artifactId>spring-webmvc</artifactId>\n80  \t\t\t<version>${spring-framework.version}</version>\n81  \t\t</dependency>\n82  \t\t<dependency>\n83  \t\t\t<groupId>org.springframework</groupId>\n84  \t\t\t<artifactId>spring-web</artifactId>\n85  \t\t\t<version>${spring-framework.version}</version>\n86  \t\t</dependency>\n87  \t\t<dependency>\n88  \t\t\t<groupId>org.springframework.boot</groupId>\n89  \t\t\t<artifactId>spring-boot-starter-actuator</artifactId>"
+        lineNumber: 78
+        variables:
+          name: org.springframework.spring-webmvc
+          version: 5.3.7
+      - uri: file:///shared/source/tackle-testapp/pom.xml
+        message: Version 6.0.0 is the minimum version of Spring that is Jakarta EE 9+ compatible
+        codeSnip: "74  \t\t\t<artifactId>spring-jdbc</artifactId>\n75  \t\t\t<version>${spring-framework.version}</version>\n76  \t\t</dependency>\n77  \t\t<dependency>\n78  \t\t\t<groupId>org.springframework</groupId>\n79  \t\t\t<artifactId>spring-webmvc</artifactId>\n80  \t\t\t<version>${spring-framework.version}</version>\n81  \t\t</dependency>\n82  \t\t<dependency>\n83  \t\t\t<groupId>org.springframework</groupId>\n84  \t\t\t<artifactId>spring-web</artifactId>\n85  \t\t\t<version>${spring-framework.version}</version>\n86  \t\t</dependency>\n87  \t\t<dependency>\n88  \t\t\t<groupId>org.springframework.boot</groupId>\n89  \t\t\t<artifactId>spring-boot-starter-actuator</artifactId>\n90  \t\t\t<version>2.5.0</version>\n91  \t\t</dependency>\n92  \t\t<dependency>\n93  \t\t\t<groupId>org.apache.tomcat</groupId>\n94  \t\t\t<artifactId>tomcat-jdbc</artifactId>"
+        lineNumber: 83
+        variables:
+          name: org.springframework.spring-web
+          version: 5.3.7
+      - uri: file:///shared/source/tackle-testapp/pom.xml
+        message: Version 6.0.0 is the minimum version of Spring that is Jakarta EE 9+ compatible
+        codeSnip: "79  \t\t\t<artifactId>spring-webmvc</artifactId>\n80  \t\t\t<version>${spring-framework.version}</version>\n81  \t\t</dependency>\n82  \t\t<dependency>\n83  \t\t\t<groupId>org.springframework</groupId>\n84  \t\t\t<artifactId>spring-web</artifactId>\n85  \t\t\t<version>${spring-framework.version}</version>\n86  \t\t</dependency>\n87  \t\t<dependency>\n88  \t\t\t<groupId>org.springframework.boot</groupId>\n89  \t\t\t<artifactId>spring-boot-starter-actuator</artifactId>\n90  \t\t\t<version>2.5.0</version>\n91  \t\t</dependency>\n92  \t\t<dependency>\n93  \t\t\t<groupId>org.apache.tomcat</groupId>\n94  \t\t\t<artifactId>tomcat-jdbc</artifactId>\n95  \t\t\t<version>${tomcat.version}</version>\n96  \t\t\t<scope>runtime</scope>\n97  \t\t</dependency>\n98  \t\t<dependency>\n99  \t\t\t<groupId>org.hibernate</groupId>"
+        lineNumber: 88
+        variables:
+          name: org.springframework.boot.spring-boot-starter-actuator
+          version: 2.5.0
+      links:
+      - url: https://spring.io/blog/2021/09/02/a-java-17-and-jakarta-ee-9-baseline-for-spring-framework-6/
+        title: A Java 17 and Jakarta EE 9 baseline for Spring Framework 6
+      effort: 3
+- name: technology-usage
+  description: This ruleset provides analysis of logging libraries.
+  tags:
+  - Bean=EJB XML
+  - Connect=EJB XML
+  - Connect=Servlet
+  - Embedded Spring Data JPA
+  - Embedded framework - Micrometer
+  - Embedded framework - Spring DI
+  - Embedded framework - Spring MVC
+  - Embedded framework - Spring Web
+  - Embedded library - Spring Boot Actuator
+  - Embedded=Micrometer
+  - Embedded=Properties
+  - Embedded=Spring DI
+  - Embedded=Spring Data JPA
+  - Embedded=Spring Web
+  - Execute=Micrometer
+  - Execute=Spring DI
+  - HTTP=Servlet
+  - Integration=Micrometer
+  - Inversion of Control=Spring DI
+  - Java EE=EJB XML
+  - Java EE=JPA named queries
+  - Java EE=Servlet
+  - Java Servlet
+  - Micrometer
+  - Other=Properties
+  - Persistence=JPA named queries
+  - Persistence=Spring Data JPA
+  - Servlet
+  - Spring Boot Actuator
+  - Spring DI
+  - Spring Data JPA
+  - Spring MVC
+  - Spring Web
+  - Store=JPA named queries
+  - Store=Spring Data JPA
+  - Sustain=Properties
+  - View=Spring Web
+  - Web=Spring Web
+  insights:
+    database-03000:
+      description: Embedded Spring Data JPA
+      labels:
+      - discovery
+      - konveyor.io/include=always
+      - tag=Embedded Spring Data JPA
+      - tag=Spring Data JPA
+      incidents:
+      - uri: file:///shared/source/tackle-testapp/pom.xml
+        message: ""
+        codeSnip: "59  \t\t<dependency>\n60  \t\t\t<groupId>com.fasterxml.jackson.core</groupId>\n61  \t\t\t<artifactId>jackson-core</artifactId>\n62  \t\t</dependency>\n63  \t\t<dependency>\n64  \t\t\t<groupId>com.fasterxml.jackson.core</groupId>\n65  \t\t\t<artifactId>jackson-databind</artifactId>\n66  \t\t</dependency>\n67  \t\t<dependency>\n68  \t\t\t<groupId>org.springframework.data</groupId>\n69  \t\t\t<artifactId>spring-data-jpa</artifactId>\n70  \t\t</dependency>\n71  \n72  \t\t<dependency>\n73  \t\t\t<groupId>org.springframework</groupId>\n74  \t\t\t<artifactId>spring-jdbc</artifactId>\n75  \t\t\t<version>${spring-framework.version}</version>\n76  \t\t</dependency>\n77  \t\t<dependency>\n78  \t\t\t<groupId>org.springframework</groupId>\n79  \t\t\t<artifactId>spring-webmvc</artifactId>"
+        lineNumber: 68
+        variables:
+          name: org.springframework.data.spring-data-jpa
+          version: 2.5.1
+    embedded-framework-08200:
+      description: Embedded framework - Spring DI
+      labels:
+      - discovery
+      - konveyor.io/include=always
+      - tag=Embedded framework - Spring DI
+      - tag=Spring DI
+      incidents:
+      - uri: file:///shared/source/tackle-testapp/pom.xml
+        message: ""
+        codeSnip: "59  \t\t<dependency>\n60  \t\t\t<groupId>com.fasterxml.jackson.core</groupId>\n61  \t\t\t<artifactId>jackson-core</artifactId>\n62  \t\t</dependency>\n63  \t\t<dependency>\n64  \t\t\t<groupId>com.fasterxml.jackson.core</groupId>\n65  \t\t\t<artifactId>jackson-databind</artifactId>\n66  \t\t</dependency>\n67  \t\t<dependency>\n68  \t\t\t<groupId>org.springframework.data</groupId>\n69  \t\t\t<artifactId>spring-data-jpa</artifactId>\n70  \t\t</dependency>\n71  \n72  \t\t<dependency>\n73  \t\t\t<groupId>org.springframework</groupId>\n74  \t\t\t<artifactId>spring-jdbc</artifactId>\n75  \t\t\t<version>${spring-framework.version}</version>\n76  \t\t</dependency>\n77  \t\t<dependency>\n78  \t\t\t<groupId>org.springframework</groupId>\n79  \t\t\t<artifactId>spring-webmvc</artifactId>"
+        lineNumber: 68
+        variables:
+          name: org.springframework.spring-beans
+          version: 5.3.7
+    embedded-framework-08300:
+      description: Embedded framework - Micrometer
+      labels:
+      - discovery
+      - konveyor.io/include=always
+      - tag=Embedded framework - Micrometer
+      - tag=Micrometer
+      incidents:
+      - uri: file:///shared/source/tackle-testapp/pom.xml
+        message: ""
+        codeSnip: "79  \t\t\t<artifactId>spring-webmvc</artifactId>\n80  \t\t\t<version>${spring-framework.version}</version>\n81  \t\t</dependency>\n82  \t\t<dependency>\n83  \t\t\t<groupId>org.springframework</groupId>\n84  \t\t\t<artifactId>spring-web</artifactId>\n85  \t\t\t<version>${spring-framework.version}</version>\n86  \t\t</dependency>\n87  \t\t<dependency>\n88  \t\t\t<groupId>org.springframework.boot</groupId>\n89  \t\t\t<artifactId>spring-boot-starter-actuator</artifactId>\n90  \t\t\t<version>2.5.0</version>\n91  \t\t</dependency>\n92  \t\t<dependency>\n93  \t\t\t<groupId>org.apache.tomcat</groupId>\n94  \t\t\t<artifactId>tomcat-jdbc</artifactId>\n95  \t\t\t<version>${tomcat.version}</version>\n96  \t\t\t<scope>runtime</scope>\n97  \t\t</dependency>\n98  \t\t<dependency>\n99  \t\t\t<groupId>org.hibernate</groupId>"
+        lineNumber: 88
+        variables:
+          name: io.micrometer.micrometer-core
+          version: 1.7.0
+    embedded-framework-08400:
+      description: Embedded framework - Spring Web
+      labels:
+      - discovery
+      - konveyor.io/include=always
+      - tag=Embedded framework - Spring Web
+      - tag=Spring Web
+      incidents:
+      - uri: file:///shared/source/tackle-testapp/pom.xml
+        message: ""
+        codeSnip: "74  \t\t\t<artifactId>spring-jdbc</artifactId>\n75  \t\t\t<version>${spring-framework.version}</version>\n76  \t\t</dependency>\n77  \t\t<dependency>\n78  \t\t\t<groupId>org.springframework</groupId>\n79  \t\t\t<artifactId>spring-webmvc</artifactId>\n80  \t\t\t<version>${spring-framework.version}</version>\n81  \t\t</dependency>\n82  \t\t<dependency>\n83  \t\t\t<groupId>org.springframework</groupId>\n84  \t\t\t<artifactId>spring-web</artifactId>\n85  \t\t\t<version>${spring-framework.version}</version>\n86  \t\t</dependency>\n87  \t\t<dependency>\n88  \t\t\t<groupId>org.springframework.boot</groupId>\n89  \t\t\t<artifactId>spring-boot-starter-actuator</artifactId>\n90  \t\t\t<version>2.5.0</version>\n91  \t\t</dependency>\n92  \t\t<dependency>\n93  \t\t\t<groupId>org.apache.tomcat</groupId>\n94  \t\t\t<artifactId>tomcat-jdbc</artifactId>"
+        lineNumber: 83
+        variables:
+          name: org.springframework.spring-web
+          version: 5.3.7
+    javaee-technology-usage-00120:
+      description: Java Servlet
+      labels:
+      - discovery
+      - konveyor.io/include=always
+      - tag=Java Servlet
+      - tag=Servlet
+      incidents:
+      - uri: file:///shared/source/tackle-testapp/src/main/java/io/konveyor/demo/ordermanagement/OrderManagementAppInitializer.java
+        message: ""
+        codeSnip: " 1  package io.konveyor.demo.ordermanagement;\n 2  \n 3  import javax.servlet.ServletContext;\n 4  import javax.servlet.ServletException;\n 5  import javax.servlet.ServletRegistration;\n 6  \n 7  import org.springframework.web.WebApplicationInitializer;\n 8  import org.springframework.web.context.ContextLoaderListener;\n 9  import org.springframework.web.context.support.AnnotationConfigWebApplicationContext;\n10  import org.springframework.web.servlet.DispatcherServlet;\n11  \n12  public class OrderManagementAppInitializer implements WebApplicationInitializer  {\n13  "
+        lineNumber: 3
+        variables:
+          file: file:///shared/source/tackle-testapp/src/main/java/io/konveyor/demo/ordermanagement/OrderManagementAppInitializer.java
+          kind: Module
+          name: javax.servlet.ServletContext
+          package: io.konveyor.demo.ordermanagement
+      - uri: file:///shared/source/tackle-testapp/src/main/java/io/konveyor/demo/ordermanagement/OrderManagementAppInitializer.java
+        message: ""
+        codeSnip: " 1  package io.konveyor.demo.ordermanagement;\n 2  \n 3  import javax.servlet.ServletContext;\n 4  import javax.servlet.ServletException;\n 5  import javax.servlet.ServletRegistration;\n 6  \n 7  import org.springframework.web.WebApplicationInitializer;\n 8  import org.springframework.web.context.ContextLoaderListener;\n 9  import org.springframework.web.context.support.AnnotationConfigWebApplicationContext;\n10  import org.springframework.web.servlet.DispatcherServlet;\n11  \n12  public class OrderManagementAppInitializer implements WebApplicationInitializer  {\n13  \n14  \t@Override"
+        lineNumber: 4
+        variables:
+          file: file:///shared/source/tackle-testapp/src/main/java/io/konveyor/demo/ordermanagement/OrderManagementAppInitializer.java
+          kind: Module
+          name: javax.servlet.ServletException
+          package: io.konveyor.demo.ordermanagement
+      - uri: file:///shared/source/tackle-testapp/src/main/java/io/konveyor/demo/ordermanagement/OrderManagementAppInitializer.java
+        message: ""
+        codeSnip: " 1  package io.konveyor.demo.ordermanagement;\n 2  \n 3  import javax.servlet.ServletContext;\n 4  import javax.servlet.ServletException;\n 5  import javax.servlet.ServletRegistration;\n 6  \n 7  import org.springframework.web.WebApplicationInitializer;\n 8  import org.springframework.web.context.ContextLoaderListener;\n 9  import org.springframework.web.context.support.AnnotationConfigWebApplicationContext;\n10  import org.springframework.web.servlet.DispatcherServlet;\n11  \n12  public class OrderManagementAppInitializer implements WebApplicationInitializer  {\n13  \n14  \t@Override\n15  \tpublic void onStartup(ServletContext container) throws ServletException {"
+        lineNumber: 5
+        variables:
+          file: file:///shared/source/tackle-testapp/src/main/java/io/konveyor/demo/ordermanagement/OrderManagementAppInitializer.java
+          kind: Module
+          name: javax.servlet.ServletRegistration
+          package: io.konveyor.demo.ordermanagement
+    javaee-technology-usage-00230:
+      description: ""
+      labels:
+      - discovery
+      - konveyor.io/include=always
+      - tag=Connect=Servlet
+      - tag=HTTP=Servlet
+      - tag=Java EE=Servlet
+      incidents:
+      - uri: ""
+        message: ""
+        variables:
+          tags:
+          - Servlet
+    mvc-01220:
+      description: Embedded framework - Spring MVC
+      labels:
+      - discovery
+      - konveyor.io/include=always
+      - tag=Embedded framework - Spring MVC
+      - tag=Spring MVC
+      incidents:
+      - uri: file:///shared/source/tackle-testapp/pom.xml
+        message: ""
+        codeSnip: "69  \t\t\t<artifactId>spring-data-jpa</artifactId>\n70  \t\t</dependency>\n71  \n72  \t\t<dependency>\n73  \t\t\t<groupId>org.springframework</groupId>\n74  \t\t\t<artifactId>spring-jdbc</artifactId>\n75  \t\t\t<version>${spring-framework.version}</version>\n76  \t\t</dependency>\n77  \t\t<dependency>\n78  \t\t\t<groupId>org.springframework</groupId>\n79  \t\t\t<artifactId>spring-webmvc</artifactId>\n80  \t\t\t<version>${spring-framework.version}</version>\n81  \t\t</dependency>\n82  \t\t<dependency>\n83  \t\t\t<groupId>org.springframework</groupId>\n84  \t\t\t<artifactId>spring-web</artifactId>\n85  \t\t\t<version>${spring-framework.version}</version>\n86  \t\t</dependency>\n87  \t\t<dependency>\n88  \t\t\t<groupId>org.springframework.boot</groupId>\n89  \t\t\t<artifactId>spring-boot-starter-actuator</artifactId>"
+        lineNumber: 78
+        variables:
+          name: org.springframework.spring-webmvc
+          version: 5.3.7
+    non-xml-technology-usage-02000:
+      description: ""
+      labels:
+      - discovery
+      - konveyor.io/include=always
+      - tag=Bean=EJB XML
+      - tag=Connect=EJB XML
+      - tag=Java EE=EJB XML
+      incidents:
+      - uri: ""
+        message: ""
+        variables:
+          tags:
+          - EJB XML
+    non-xml-technology-usage-20000:
+      description: ""
+      labels:
+      - discovery
+      - konveyor.io/include=always
+      - tag=Embedded=Properties
+      - tag=Other=Properties
+      - tag=Sustain=Properties
+      incidents:
+      - uri: ""
+        message: ""
+        variables:
+          tags:
+          - Properties
+    observability-0100:
+      description: Embedded library - Spring Boot Actuator
+      labels:
+      - discovery
+      - konveyor.io/include=always
+      - tag=Embedded library - Spring Boot Actuator
+      - tag=Spring Boot Actuator
+      incidents:
+      - uri: file:///shared/source/tackle-testapp/pom.xml
+        message: ""
+        codeSnip: "79  \t\t\t<artifactId>spring-webmvc</artifactId>\n80  \t\t\t<version>${spring-framework.version}</version>\n81  \t\t</dependency>\n82  \t\t<dependency>\n83  \t\t\t<groupId>org.springframework</groupId>\n84  \t\t\t<artifactId>spring-web</artifactId>\n85  \t\t\t<version>${spring-framework.version}</version>\n86  \t\t</dependency>\n87  \t\t<dependency>\n88  \t\t\t<groupId>org.springframework.boot</groupId>\n89  \t\t\t<artifactId>spring-boot-starter-actuator</artifactId>\n90  \t\t\t<version>2.5.0</version>\n91  \t\t</dependency>\n92  \t\t<dependency>\n93  \t\t\t<groupId>org.apache.tomcat</groupId>\n94  \t\t\t<artifactId>tomcat-jdbc</artifactId>\n95  \t\t\t<version>${tomcat.version}</version>\n96  \t\t\t<scope>runtime</scope>\n97  \t\t</dependency>\n98  \t\t<dependency>\n99  \t\t\t<groupId>org.hibernate</groupId>"
+        lineNumber: 88
+        variables:
+          name: org.springframework.boot.spring-boot-starter-actuator
+          version: 2.5.0
+    technology-usage-database-01200:
+      description: ""
+      labels:
+      - discovery
+      - konveyor.io/include=always
+      - tag=Java EE=JPA named queries
+      - tag=Persistence=JPA named queries
+      - tag=Store=JPA named queries
+      incidents:
+      - uri: file:///shared/source/tackle-testapp/src/main/java/io/konveyor/demo/ordermanagement/model/Customer.java
+        message: ""
+        codeSnip: " 1  package io.konveyor.demo.ordermanagement.model;\n 2  \n 3  import javax.persistence.Column;\n 4  import javax.persistence.Entity;\n 5  import javax.persistence.GeneratedValue;\n 6  import javax.persistence.GenerationType;\n 7  import javax.persistence.Id;\n 8  import javax.persistence.SequenceGenerator;\n 9  import javax.persistence.Table;\n10  \n11  @Entity\n12  @Table(name = \"customers\")\n13  public class Customer {\n14  \t@Id\n15      @SequenceGenerator(\n16              name = \"customersSequence\",\n17              sequenceName = \"customers_id_seq\",\n18              allocationSize = 1,\n19              initialValue = 6)\n20      @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = \"customersSequence\")\n21  \tprivate Long id;"
+        lineNumber: 11
+        variables:
+          file: file:///shared/source/tackle-testapp/src/main/java/io/konveyor/demo/ordermanagement/model/Customer.java
+          kind: Class
+          name: Entity
+          package: io.konveyor.demo.ordermanagement.model
+      - uri: file:///shared/source/tackle-testapp/src/main/java/io/konveyor/demo/ordermanagement/model/Customer.java
+        message: ""
+        codeSnip: " 2  \n 3  import javax.persistence.Column;\n 4  import javax.persistence.Entity;\n 5  import javax.persistence.GeneratedValue;\n 6  import javax.persistence.GenerationType;\n 7  import javax.persistence.Id;\n 8  import javax.persistence.SequenceGenerator;\n 9  import javax.persistence.Table;\n10  \n11  @Entity\n12  @Table(name = \"customers\")\n13  public class Customer {\n14  \t@Id\n15      @SequenceGenerator(\n16              name = \"customersSequence\",\n17              sequenceName = \"customers_id_seq\",\n18              allocationSize = 1,\n19              initialValue = 6)\n20      @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = \"customersSequence\")\n21  \tprivate Long id;\n22  \t"
+        lineNumber: 12
+        variables:
+          file: file:///shared/source/tackle-testapp/src/main/java/io/konveyor/demo/ordermanagement/model/Customer.java
+          kind: Class
+          name: Entity
+          package: io.konveyor.demo.ordermanagement.model
+    technology-usage-database-03100:
+      description: ""
+      labels:
+      - discovery
+      - konveyor.io/include=always
+      - tag=Embedded=Spring Data JPA
+      - tag=Persistence=Spring Data JPA
+      - tag=Store=Spring Data JPA
+      incidents:
+      - uri: ""
+        message: ""
+        variables:
+          tags:
+          - Spring Data JPA
+    technology-usage-embedded-framework-08200:
+      description: ""
+      labels:
+      - discovery
+      - konveyor.io/include=always
+      - tag=Embedded=Spring DI
+      - tag=Execute=Spring DI
+      - tag=Inversion of Control=Spring DI
+      incidents:
+      - uri: ""
+        message: ""
+        variables:
+          tags:
+          - Spring DI
+    technology-usage-embedded-framework-08300:
+      description: ""
+      labels:
+      - discovery
+      - konveyor.io/include=always
+      - tag=Embedded=Micrometer
+      - tag=Execute=Micrometer
+      - tag=Integration=Micrometer
+      incidents:
+      - uri: ""
+        message: ""
+        variables:
+          tags:
+          - Micrometer
+    technology-usage-embedded-framework-08400:
+      description: ""
+      labels:
+      - discovery
+      - konveyor.io/include=always
+      - tag=Embedded=Spring Web
+      - tag=View=Spring Web
+      - tag=Web=Spring Web
+      incidents:
+      - uri: ""
+        message: ""
+        variables:
+          tags:
+          - Spring Web
+  unmatched:
+  - 3rd-party-01000
+  - 3rd-party-02000
+  - 3rd-party-03000
+  - 3rd-party-04000
+  - 3rd-party-05000
+  - 3rd-party-06000
+  - 3rd-party-07000
+  - 3rd-party-08000
+  - 3rd-party-09000
+  - 3rd-party-10000
+  - 3rd-party-11000
+  - 3rd-party-12000
+  - 3rd-party-13000
+  - 3rd-party-14000
+  - 3rd-party-15000
+  - 3rd-party-16000
+  - 3rd-party-17000
+  - 3rd-party-18000
+  - 3rd-party-19000
+  - 3rd-party-spring-03001
+  - 3rd-party-spring-03002
+  - apm-00000
+  - apm-00001
+  - apm-00002
+  - apm-00003
+  - clustering-00000
+  - clustering-00001
+  - configuration-management-0100
+  - configuration-management-0200
+  - configuration-management-0300
+  - configuration-management-0400
+  - configuration-management-0500
+  - configuration-management-technology-usage-0100
+  - configuration-management-technology-usage-0200
+  - configuration-management-technology-usage-0300
+  - connect-01400
+  - connect-01500
+  - connect-01600
+  - connect-01700
+  - connect-01800
+  - connect-01900
+  - connect-02000
+  - connect-02100
+  - connect-02200
+  - connect-02300
+  - connect-02400
+  - connect-02500
+  - connect-02600
+  - connect-02700
+  - connect-02800
+  - connect-02900
+  - database-01400
+  - database-01400
+  - database-01500
+  - database-01600
+  - database-01700
+  - database-01800
+  - database-01805
+  - database-01900
+  - database-02000
+  - database-02100
+  - database-02200
+  - database-02300
+  - database-02400
+  - database-02500
+  - database-02600
+  - database-02700
+  - database-02800
+  - database-02900
+  - database-03100
+  - ejb-01000
+  - embedded-cache-libraries-01000
+  - embedded-cache-libraries-02000
+  - embedded-cache-libraries-03000
+  - embedded-cache-libraries-04000
+  - embedded-cache-libraries-05000
+  - embedded-cache-libraries-06000
+  - embedded-cache-libraries-07000
+  - embedded-cache-libraries-08000
+  - embedded-cache-libraries-09000
+  - embedded-cache-libraries-10000
+  - embedded-cache-libraries-11000
+  - embedded-cache-libraries-12000
+  - embedded-cache-libraries-13000
+  - embedded-cache-libraries-14000
+  - embedded-cache-libraries-15000
+  - embedded-cache-libraries-16000
+  - embedded-framework-01000
+  - embedded-framework-01010
+  - embedded-framework-01100
+  - embedded-framework-01200
+  - embedded-framework-01300
+  - embedded-framework-01400
+  - embedded-framework-01500
+  - embedded-framework-01600
+  - embedded-framework-01700
+  - embedded-framework-02000
+  - embedded-framework-02200
+  - embedded-framework-02300
+  - embedded-framework-02400
+  - embedded-framework-03000
+  - embedded-framework-03100
+  - embedded-framework-03200
+  - embedded-framework-03300
+  - embedded-framework-03400
+  - embedded-framework-04700
+  - embedded-framework-05000
+  - embedded-framework-05100
+  - embedded-framework-05300
+  - embedded-framework-05400
+  - embedded-framework-05500
+  - embedded-framework-05600
+  - embedded-framework-05700
+  - embedded-framework-05800
+  - embedded-framework-05900
+  - embedded-framework-06000
+  - embedded-framework-06100
+  - embedded-framework-06200
+  - embedded-framework-06300
+  - embedded-framework-06400
+  - embedded-framework-06500
+  - embedded-framework-06600
+  - embedded-framework-06700
+  - embedded-framework-06800
+  - embedded-framework-06900
+  - embedded-framework-07000
+  - embedded-framework-07100
+  - embedded-framework-07200
+  - embedded-framework-07300
+  - embedded-framework-07400
+  - embedded-framework-07500
+  - embedded-framework-07600
+  - embedded-framework-07700
+  - embedded-framework-07800
+  - embedded-framework-07900
+  - embedded-framework-08000
+  - embedded-framework-08100
+  - embedded-framework-08500
+  - embedded-framework-08600
+  - embedded-framework-08700
+  - embedded-framework-08800
+  - embedded-framework-08900
+  - embedded-framework-09000
+  - embedded-framework-09100
+  - embedded-framework-09300
+  - embedded-framework-embedded-framework-02700
+  - embedded-framework-embedded-framework-02800
+  - embedded-framework-embedded-framework-02900
+  - embedded-framework-embedded-framework-03000
+  - embedded-framework-embedded-framework-03100
+  - embedded-framework-embedded-framework-03200
+  - embedded-framework-embedded-framework-03300
+  - embedded-framework-embedded-framework-03400
+  - embedded-framework-embedded-framework-03500
+  - embedded-framework-embedded-framework-03600
+  - embedded-framework-embedded-framework-03700
+  - embedded-framework-embedded-framework-03800
+  - embedded-framework-embedded-framework-03900
+  - embedded-framework-embedded-framework-04000
+  - embedded-framework-embedded-framework-04100
+  - embedded-framework-embedded-framework-04200
+  - embedded-framework-embedded-framework-04300
+  - embedded-framework-embedded-framework-04400
+  - embedded-framework-embedded-framework-04500
+  - embedded-framework-embedded-framework-04600
+  - embedded-framework-embedded-framework-09200
+  - embedded-framework-embedded-framework-09300
+  - integration-00001
+  - integration-00002
+  - integration-00003
+  - integration-00004
+  - integration-00005
+  - integration-00006
+  - integration-00007
+  - integration-00008
+  - integration-00009
+  - integration-00010
+  - integration-00011
+  - integration-00012
+  - integration-00013
+  - integration-00014
+  - integration-00015
+  - integration-00016
+  - integration-00017
+  - javaee-technology-usage-00010
+  - javaee-technology-usage-00011
+  - javaee-technology-usage-00012
+  - javaee-technology-usage-00013
+  - javaee-technology-usage-00020-jakarta
+  - javaee-technology-usage-00020-javax
+  - javaee-technology-usage-00021
+  - javaee-technology-usage-00030
+  - javaee-technology-usage-00031
+  - javaee-technology-usage-00040
+  - javaee-technology-usage-00050
+  - javaee-technology-usage-00060
+  - javaee-technology-usage-00070
+  - javaee-technology-usage-00080
+  - javaee-technology-usage-00090
+  - javaee-technology-usage-00100
+  - javaee-technology-usage-00110
+  - javaee-technology-usage-00130
+  - javaee-technology-usage-00140
+  - javaee-technology-usage-00150
+  - javaee-technology-usage-00160
+  - javaee-technology-usage-00170
+  - javaee-technology-usage-00180
+  - javaee-technology-usage-00190
+  - javaee-technology-usage-00200
+  - javaee-technology-usage-00210
+  - javaee-technology-usage-00220
+  - javaee-technology-usage-00902
+  - javaee-technology-usage-00903
+  - javaee-technology-usage-00905
+  - javaee-technology-usage-00906
+  - javaee-technology-usage-00910
+  - javaee-technology-usage-00911
+  - javaee-technology-usage-00912
+  - javaee-technology-usage-00913
+  - javaee-technology-usage-00914
+  - javaee-technology-usage-00915
+  - javaee-technology-usage-00916
+  - javaee-technology-usage-00917
+  - javaee-technology-usage-00918
+  - javaee-technology-usage-00926
+  - javaee-technology-usage-00927
+  - javaee-technology-usage-00928
+  - javaee-technology-usage-00930
+  - javaee-technology-usage-00931
+  - javaee-technology-usage-00932
+  - javaee-technology-usage-00950
+  - javaee-technology-usage-00951
+  - javaee-technology-usage-00952
+  - javaee-technology-usage-00953
+  - javaee-technology-usage-00954
+  - javaee-technology-usage-00955
+  - javaee-technology-usage-00956
+  - javaee-technology-usage-00957
+  - javaee-technology-usage-00958
+  - javase-01000
+  - javase-01100
+  - javase-technology-usage-01000
+  - jta-00020
+  - jta-00030
+  - jta-00040
+  - jta-00050
+  - jta-00060
+  - jta-00070
+  - jta-00080
+  - jta-00090
+  - jta-00100
+  - jta-00110
+  - jta-00120
+  - jta-00130
+  - jta-00140
+  - jta-00150
+  - jta-00160
+  - jta-00170
+  - jta-00180
+  - jta-00190
+  - jta-00200
+  - jta-00210
+  - logging-usage-00010
+  - logging-usage-00020
+  - logging-usage-00030
+  - logging-usage-00040
+  - logging-usage-00050
+  - logging-usage-00080
+  - logging-usage-00090
+  - logging-usage-00100
+  - logging-usage-00110
+  - logging-usage-00120
+  - logging-usage-00130
+  - logging-usage-00140
+  - logging-usage-00150
+  - logging-usage-00160
+  - logging-usage-00170
+  - logging-usage-00180
+  - logging-usage-00190
+  - logging-usage-00200
+  - logging-usage-00210
+  - logging-usage-00220
+  - logging-usage-00230
+  - logging-usage-00240
+  - logging-usage-00250
+  - logging-usage-00260
+  - logging-usage-00270
+  - logging-usage-00280
+  - logging-usage-00290
+  - mvc-01000
+  - mvc-01100
+  - mvc-01200
+  - mvc-01210
+  - mvc-01300
+  - mvc-01400
+  - mvc-01500
+  - mvc-01600
+  - mvc-01700
+  - mvc-01800
+  - mvc-01900
+  - mvc-02000
+  - mvc-02100
+  - mvc-02200
+  - mvc-02300
+  - mvc-02400
+  - mvc-02500
+  - mvc-02600
+  - mvc-02700
+  - mvc-02800
+  - mvc-02900
+  - mvc-03000
+  - mvc-03100
+  - mvc-03200
+  - mvc-03300
+  - mvc-03400
+  - mvc-03500
+  - mvc-03600
+  - mvc-03700
+  - mvc-03800
+  - mvc-03900
+  - mvc-04000
+  - mvc-04100
+  - mvc-04200
+  - mvc-04300
+  - mvc-04400
+  - mvc-04500
+  - mvc-04600
+  - mvc-04700
+  - mvc-04800
+  - mvc-04900
+  - mvc-05000
+  - mvc-05100
+  - mvc-05200
+  - mvc-05300
+  - mvc-05400
+  - mvc-05500
+  - mvc-05600
+  - mvc-05700
+  - mvc-05800
+  - mvc-05900
+  - mvc-06000
+  - non-xml-technology-usage-05000
+  - non-xml-technology-usage-06000
+  - non-xml-technology-usage-12000
+  - non-xml-technology-usage-13000
+  - non-xml-technology-usage-14000
+  - non-xml-technology-usage-17000
+  - non-xml-technology-usage-18000
+  - non-xml-technology-usage-19000
+  - non-xml-technology-usage-21000
+  - non-xml-technology-usage-22000
+  - non-xml-technology-usage-23000
+  - non-xml-technology-usage-24000
+  - non-xml-technology-usage-25000
+  - non-xml-technology-usage-26000
+  - non-xml-technology-usage-27000
+  - observability-0200
+  - observability-technology-usage-0100
+  - observability-technology-usage-0200
+  - security-01100
+  - security-01200
+  - security-01300
+  - security-01400
+  - security-01500
+  - security-01600
+  - security-01700
+  - security-01800
+  - security-01900
+  - security-02000
+  - security-02100
+  - security-02200
+  - security-02300
+  - security-02400
+  - security-02500
+  - security-02600
+  - security-02700
+  - security-02800
+  - security-02900
+  - security-03000
+  - security-03100
+  - security-03200
+  - security-03300
+  - security-03400
+  - security-03500
+  - security-03600
+  - spring-catchall-00001
+  - technology-usage-3rd-party-01000
+  - technology-usage-3rd-party-02000
+  - technology-usage-3rd-party-03000
+  - technology-usage-3rd-party-04000
+  - technology-usage-3rd-party-05000
+  - technology-usage-3rd-party-06000
+  - technology-usage-3rd-party-08000
+  - technology-usage-3rd-party-09000
+  - technology-usage-3rd-party-10000
+  - technology-usage-3rd-party-11000
+  - technology-usage-3rd-party-12000
+  - technology-usage-3rd-party-13000
+  - technology-usage-3rd-party-14000
+  - technology-usage-3rd-party-15000
+  - technology-usage-3rd-party-16000
+  - technology-usage-3rd-party-17000
+  - technology-usage-3rd-party-18000
+  - technology-usage-3rd-party-19000
+  - technology-usage-3rd-party-20000
+  - technology-usage-3rd-party-spring-03001-0
+  - technology-usage-3rd-party-spring-03001-1
+  - technology-usage-3rd-party-spring-03001-2
+  - technology-usage-3rd-party-spring-03002
+  - technology-usage-apm-00010
+  - technology-usage-apm-00020
+  - technology-usage-apm-00030
+  - technology-usage-apm-00040
+  - technology-usage-clustering-01000
+  - technology-usage-clustering-02000
+  - technology-usage-connect-01000
+  - technology-usage-connect-01100
+  - technology-usage-connect-01101
+  - technology-usage-connect-01200
+  - technology-usage-connect-01300
+  - technology-usage-connect-01400
+  - technology-usage-connect-01500
+  - technology-usage-connect-01600
+  - technology-usage-connect-01700
+  - technology-usage-connect-01800
+  - technology-usage-connect-01900
+  - technology-usage-connect-02000
+  - technology-usage-connect-02100
+  - technology-usage-connect-02200
+  - technology-usage-connect-02300
+  - technology-usage-connect-02400
+  - technology-usage-connect-02500
+  - technology-usage-connect-02600
+  - technology-usage-connect-02700
+  - technology-usage-connect-02800
+  - technology-usage-connect-02900
+  - technology-usage-database-01000
+  - technology-usage-database-01001
+  - technology-usage-database-01100
+  - technology-usage-database-01300
+  - technology-usage-database-01400
+  - technology-usage-database-01500
+  - technology-usage-database-01600
+  - technology-usage-database-01700
+  - technology-usage-database-01800
+  - technology-usage-database-01900
+  - technology-usage-database-02000
+  - technology-usage-database-02100
+  - technology-usage-database-02200
+  - technology-usage-database-02300
+  - technology-usage-database-02400
+  - technology-usage-database-02500
+  - technology-usage-database-02600
+  - technology-usage-database-02700
+  - technology-usage-database-02800
+  - technology-usage-database-02900
+  - technology-usage-database-03000
+  - technology-usage-database-03200
+  - technology-usage-ejb-01400
+  - technology-usage-embedded-framework-01000
+  - technology-usage-embedded-framework-01010
+  - technology-usage-embedded-framework-01100
+  - technology-usage-embedded-framework-01200
+  - technology-usage-embedded-framework-01300
+  - technology-usage-embedded-framework-01400
+  - technology-usage-embedded-framework-01500
+  - technology-usage-embedded-framework-01600
+  - technology-usage-embedded-framework-01700
+  - technology-usage-embedded-framework-02000
+  - technology-usage-embedded-framework-02100
+  - technology-usage-embedded-framework-02200
+  - technology-usage-embedded-framework-02300
+  - technology-usage-embedded-framework-02400
+  - technology-usage-embedded-framework-04700
+  - technology-usage-embedded-framework-05000
+  - technology-usage-embedded-framework-05100
+  - technology-usage-embedded-framework-05300
+  - technology-usage-embedded-framework-05400
+  - technology-usage-embedded-framework-05600
+  - technology-usage-embedded-framework-05700
+  - technology-usage-embedded-framework-05800
+  - technology-usage-embedded-framework-05900
+  - technology-usage-embedded-framework-06000
+  - technology-usage-embedded-framework-06100
+  - technology-usage-embedded-framework-06200
+  - technology-usage-embedded-framework-06300
+  - technology-usage-embedded-framework-06400
+  - technology-usage-embedded-framework-06500
+  - technology-usage-embedded-framework-06600
+  - technology-usage-embedded-framework-06700
+  - technology-usage-embedded-framework-06800
+  - technology-usage-embedded-framework-06900
+  - technology-usage-embedded-framework-07000
+  - technology-usage-embedded-framework-07100
+  - technology-usage-embedded-framework-07200
+  - technology-usage-embedded-framework-07300
+  - technology-usage-embedded-framework-07400
+  - technology-usage-embedded-framework-07500
+  - technology-usage-embedded-framework-07600
+  - technology-usage-embedded-framework-07700
+  - technology-usage-embedded-framework-07800
+  - technology-usage-embedded-framework-07900
+  - technology-usage-embedded-framework-08000
+  - technology-usage-embedded-framework-08100
+  - technology-usage-embedded-framework-08500
+  - technology-usage-embedded-framework-08600
+  - technology-usage-embedded-framework-08700
+  - technology-usage-embedded-framework-08800
+  - technology-usage-embedded-framework-08900
+  - technology-usage-embedded-framework-09000
+  - technology-usage-embedded-framework-09100
+  - technology-usage-integration-00001
+  - technology-usage-integration-00002
+  - technology-usage-integration-00003
+  - technology-usage-integration-00004
+  - technology-usage-integration-00005
+  - technology-usage-integration-00006
+  - technology-usage-integration-00007
+  - technology-usage-integration-00008
+  - technology-usage-integration-00009
+  - technology-usage-integration-00010
+  - technology-usage-integration-00011
+  - technology-usage-integration-00012
+  - technology-usage-integration-00013
+  - technology-usage-integration-00014
+  - technology-usage-integration-00015
+  - technology-usage-jta-00020
+  - technology-usage-jta-00030
+  - technology-usage-jta-00040
+  - technology-usage-jta-00050
+  - technology-usage-jta-00060
+  - technology-usage-jta-00070
+  - technology-usage-jta-00080
+  - technology-usage-jta-00090
+  - technology-usage-jta-00100
+  - technology-usage-jta-00110
+  - technology-usage-jta-00120
+  - technology-usage-jta-00130
+  - technology-usage-jta-00140
+  - technology-usage-jta-00150
+  - technology-usage-jta-00160
+  - technology-usage-jta-00170
+  - technology-usage-jta-00180
+  - technology-usage-jta-00190
+  - technology-usage-jta-00200
+  - technology-usage-jta-00210
+  - technology-usage-logging-00010
+  - technology-usage-logging-000100
+  - technology-usage-logging-000110
+  - technology-usage-logging-000120
+  - technology-usage-logging-000130
+  - technology-usage-logging-000140
+  - technology-usage-logging-000150
+  - technology-usage-logging-000160
+  - technology-usage-logging-000170
+  - technology-usage-logging-000180
+  - technology-usage-logging-000190
+  - technology-usage-logging-00020
+  - technology-usage-logging-000200
+  - technology-usage-logging-000210
+  - technology-usage-logging-000220
+  - technology-usage-logging-000230
+  - technology-usage-logging-000240
+  - technology-usage-logging-000250
+  - technology-usage-logging-000260
+  - technology-usage-logging-000270
+  - technology-usage-logging-000280
+  - technology-usage-logging-000290
+  - technology-usage-logging-00030
+  - technology-usage-logging-00040
+  - technology-usage-logging-00050
+  - technology-usage-logging-00060
+  - technology-usage-logging-00070
+  - technology-usage-logging-00080
+  - technology-usage-logging-00090
+  - technology-usage-markup-01300
+  - technology-usage-mvc-01000
+  - technology-usage-mvc-01100
+  - technology-usage-mvc-01200
+  - technology-usage-mvc-01300
+  - technology-usage-mvc-01400
+  - technology-usage-mvc-01500
+  - technology-usage-mvc-01600
+  - technology-usage-mvc-01700
+  - technology-usage-mvc-01800
+  - technology-usage-mvc-01900
+  - technology-usage-mvc-02000
+  - technology-usage-mvc-02100
+  - technology-usage-mvc-02200
+  - technology-usage-mvc-02300
+  - technology-usage-mvc-02400
+  - technology-usage-mvc-02500
+  - technology-usage-mvc-02600
+  - technology-usage-mvc-02700
+  - technology-usage-mvc-02800
+  - technology-usage-mvc-02900
+  - technology-usage-mvc-03000
+  - technology-usage-mvc-03100
+  - technology-usage-mvc-03200
+  - technology-usage-mvc-03300
+  - technology-usage-mvc-03400
+  - technology-usage-mvc-03500
+  - technology-usage-mvc-03600
+  - technology-usage-mvc-03700
+  - technology-usage-mvc-03800
+  - technology-usage-mvc-03900
+  - technology-usage-mvc-04000
+  - technology-usage-mvc-04100
+  - technology-usage-mvc-04300
+  - technology-usage-mvc-04400
+  - technology-usage-mvc-04500
+  - technology-usage-mvc-04600
+  - technology-usage-mvc-04700
+  - technology-usage-mvc-04800
+  - technology-usage-mvc-04900
+  - technology-usage-mvc-05000
+  - technology-usage-mvc-05100
+  - technology-usage-mvc-05200
+  - technology-usage-mvc-05300
+  - technology-usage-mvc-05400
+  - technology-usage-mvc-05500
+  - technology-usage-mvc-05600
+  - technology-usage-mvc-05700
+  - technology-usage-mvc-05800
+  - technology-usage-mvc-05900
+  - technology-usage-mvc-06000
+  - technology-usage-mvc-0x4200
+  - technology-usage-security-01000
+  - technology-usage-security-01100
+  - technology-usage-security-01200
+  - technology-usage-security-01300
+  - technology-usage-security-01400
+  - technology-usage-security-01500
+  - technology-usage-security-01600
+  - technology-usage-security-01700
+  - technology-usage-security-01800
+  - technology-usage-security-01900
+  - technology-usage-security-02000
+  - technology-usage-security-02100
+  - technology-usage-security-02200
+  - technology-usage-security-02300
+  - technology-usage-security-02400
+  - technology-usage-security-02500
+  - technology-usage-security-02600
+  - technology-usage-security-02700
+  - technology-usage-security-02800
+  - technology-usage-security-02900
+  - technology-usage-security-03000
+  - technology-usage-security-03100
+  - technology-usage-security-03200
+  - technology-usage-security-03300
+  - technology-usage-security-03400
+  - technology-usage-security-03500
+  - technology-usage-test-frameworks-00010
+  - technology-usage-test-frameworks-00020
+  - technology-usage-test-frameworks-00030
+  - technology-usage-test-frameworks-00040
+  - technology-usage-test-frameworks-00050
+  - technology-usage-test-frameworks-00060
+  - technology-usage-test-frameworks-00070
+  - technology-usage-test-frameworks-00080
+  - technology-usage-test-frameworks-00090
+  - technology-usage-test-frameworks-00100
+  - technology-usage-test-frameworks-00110
+  - technology-usage-test-frameworks-00120
+  - technology-usage-test-frameworks-00130
+  - technology-usage-test-frameworks-00140
+  - technology-usage-test-frameworks-00150
+  - technology-usage-test-frameworks-00160
+  - technology-usage-test-frameworks-00170
+  - technology-usage-test-frameworks-00180
+  - technology-usage-test-frameworks-00190
+  - technology-usage-test-frameworks-00200
+  - technology-usage-test-frameworks-00210
+  - technology-usage-test-frameworks-00220
+  - technology-usage-test-frameworks-00230
+  - technology-usage-test-frameworks-00240
+  - technology-usage-test-frameworks-00250
+  - technology-usage-test-frameworks-00260
+  - technology-usage-test-frameworks-00270
+  - technology-usage-test-frameworks-00280
+  - technology-usage-test-frameworks-00290
+  - technology-usage-test-frameworks-00300
+  - technology-usage-test-frameworks-00310
+  - technology-usage-test-frameworks-00320
+  - technology-usage-test-frameworks-00330
+  - technology-usage-test-frameworks-00340
+  - technology-usage-test-frameworks-00350
+  - technology-usage-test-frameworks-00360
+  - technology-usage-test-frameworks-00370
+  - technology-usage-web-01000
+  - technology-usage-web-01100
+  - technology-usage-web-01100
+  - technology-usage-web-01200
+  - technology-usage-web-01300
+  - technology-usage-web-01300
+  - technology-usage-web-01400
+  - technology-usage-web-01400
+  - technology-usage-web-01500
+  - technology-usage-web-01500
+  - technology-usage-web-01600
+  - technology-usage-web-01600
+  - technology-usage-web-01700
+  - technology-usage-web-01700
+  - technology-usage-web-01800
+  - technology-usage-web-01800
+  - technology-usage-web-01900
+  - technology-usage-web-01900
+  - technology-usage-web-02000
+  - technology-usage-web-02000
+  - technology-usage-web-02100
+  - technology-usage-web-02100
+  - technology-usage-web-02200
+  - technology-usage-web-02200
+  - technology-usage-web-02300
+  - technology-usage-web-02300
+  - technology-usage-web-02400
+  - technology-usage-web-02400
+  - test-frameworks-sauge-00010
+  - test-frameworks-sauge-00020
+  - test-frameworks-sauge-00030
+  - test-frameworks-sauge-00040
+  - test-frameworks-sauge-00050
+  - test-frameworks-sauge-00060
+  - test-frameworks-sauge-00070
+  - test-frameworks-sauge-00080
+  - test-frameworks-sauge-00090
+  - test-frameworks-sauge-00100
+  - test-frameworks-sauge-00110
+  - test-frameworks-sauge-00120
+  - test-frameworks-sauge-00130
+  - test-frameworks-sauge-00140
+  - test-frameworks-sauge-00150
+  - test-frameworks-sauge-00160
+  - test-frameworks-sauge-00170
+  - test-frameworks-sauge-00180
+  - test-frameworks-sauge-00190
+  - test-frameworks-sauge-00200
+  - test-frameworks-sauge-00210
+  - test-frameworks-sauge-00220
+  - test-frameworks-sauge-00230
+  - test-frameworks-sauge-00240
+  - test-frameworks-sauge-00260
+  - test-frameworks-sauge-00270
+  - test-frameworks-sauge-00280
+  - test-frameworks-sauge-00290
+  - test-frameworks-sauge-00300
+  - test-frameworks-sauge-00310
+  - test-frameworks-sauge-00320
+  - test-frameworks-sauge-00330
+  - test-frameworks-sauge-00340
+  - test-frameworks-sauge-00350
+  - test-frameworks-sauge-00360
+  - test-frameworks-sauge-00370
+  - test-frameworks-sauge-00560
+  - web-01000

--- a/hack/konveyor-analyzer
+++ b/hack/konveyor-analyzer
@@ -1,0 +1,139 @@
+#!/bin/bash
+
+set -e
+#
+# Fake analyzer used for testing."
+#
+# The $ISSUES Envar is the path to an analyzer output file.
+if [ -z "${ISSUES}" ]
+then
+  ISSUES=examples/issues.yaml
+fi
+# The $DEPS Envar is the path to an analyzer (deps) output file.
+if [ -z "${DEPS}" ]
+then
+  DEPS=examples/deps.yaml
+fi
+
+# options
+RULES=()
+SETTINGS=
+OUTPUT=
+DEP_OUTPUT=
+LABEL_SELECTOR=
+DEP_LABEL_SELECTOR=
+NO_DEP_RULES=
+
+# paths relative to the script.
+cd $(dirname "$0")
+
+usage() {
+  echo "Usage: ${self} options"
+  echo "  -h help" 
+  echo "  --provider-settings"
+  echo "  --output-file"
+  echo "  --dep-output-file"
+  echo "  --rules"
+  echo "  --label-selector"
+  echo "  --dep-label-selector"
+  echo "  --no-dependency-rules"
+}
+
+run() {
+  echo "\$ $@" ; "$@" ;
+}
+
+main() {
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --provider-settings)
+        SETTINGS="$2"
+        shift 2
+        ;;
+      --provider-settings=*)
+        SETTINGS="${1#*=}"
+        shift
+        ;;
+      --output-file)
+        OUTPUT="$2"
+        shift 2
+        ;;
+      --output-file=*)
+        OUTPUT="${1#*=}"
+        shift
+        ;;
+      --dep-output-file)
+        DEP_OUTPUT="$2"
+        shift 2
+        ;;
+      --dep-output-file=*)
+        DEP_OUTPUT="${1#*=}"
+        shift
+        ;;
+      --rules)
+        RULES+=("$2")
+        shift 2
+        ;;
+      --rules=*)
+        RULES+=("${1#*=}")
+        shift
+        ;;
+      --label-selector)
+        LABEL_SELECTOR="$2"
+        shift 2
+        ;;
+      --label-selector=*)
+        LABEL_SELECTOR="${1#*=}"
+        shift
+        ;;
+      --dep-label-selector)
+        DEP_LABEL_SELECTOR="$2"
+        shift 2
+        ;;
+      --dep-label-selector=*)
+        DEP_LABEL_SELECTOR="${1#*=}"
+        shift
+        ;;
+      --no-dependency-rules)
+        NO_DEP_RULES="TRUE"
+        shift
+        ;;
+      -h)
+        usage
+        exit 0
+        ;;
+      *)
+        echo "Unknown option: $1"
+        exit 1
+        ;;
+    esac
+  done
+ 
+  # print options.
+  echo
+  echo "main:"
+  echo "  settings: ${SETTINGS}"
+  echo "     rules: ${RULES[*]}"
+  echo "    output: ${OUTPUT}"
+  echo "  selector: ${LABEL_SELECTOR}"
+  echo "dep:"
+  echo "  output: ${DEP_OUTPUT}"
+  echo "selector: ${DEP_LABEL_SELECTOR}"
+  echo "no rules: ${NO_DEP_RULES}"
+
+  # copy files.
+  if [[ -f "${ISSUES}" ]]
+  then
+    run cp ${ISSUES} ${OUTPUT}
+  fi
+  if [[ -f "${DEPS}" ]]
+  then
+    run cp ${DEPS} ${DEP_OUTPUT}
+  fi
+}
+
+main $@
+
+echo
+echo "DONE"
+


### PR DESCRIPTION
The Issues and Deps report builders need to be returned by the `Analyzer.Run()` facade having already read the analyzer output files. This ensures the files are only read once and methods may be invoked in any order.

This is a regression introduced in 0.6.0.

---

Add hack analyzer script to better support running the addon locally for testing.

---------