### PR TITLE
:bug: Support excluded labels.

### DIFF
--- a/cmd/cmd_test.go
+++ b/cmd/cmd_test.go
@@ -23,7 +23,7 @@ func TestRuleSelector(t *testing.T) {
 	expected :=
 		"((p1||p2)||((konveyor.io/source=s1||konveyor.io/source=s2)&&(konveyor.io/target=t1||konveyor.io/target=t2)))"
 	g.Expect(selector.String()).To(gomega.Equal(expected))
-	// all clauses
+	// all clauses plus excluded
 	selector = RuleSelector{}
 	selector.Included = []string{
 		"p1",

--- a/cmd/cmd_test.go
+++ b/cmd/cmd_test.go
@@ -23,6 +23,23 @@ func TestRuleSelector(t *testing.T) {
 	expected :=
 		"(p1||p2)||((konveyor.io/source=s1||konveyor.io/source=s2)&&(konveyor.io/target=t1||konveyor.io/target=t2))"
 	g.Expect(selector.String()).To(gomega.Equal(expected))
+	// all clauses
+	selector = RuleSelector{}
+	selector.Included = []string{
+		"p1",
+		"p2",
+		"konveyor.io/source=s1",
+		"konveyor.io/source=s2",
+		"konveyor.io/target=t1",
+		"konveyor.io/target=t2",
+	}
+	selector.Excluded = []string{
+		"x1",
+		"x2",
+	}
+	expected =
+		"((p1||p2)||((konveyor.io/source=s1||konveyor.io/source=s2)&&(konveyor.io/target=t1||konveyor.io/target=t2)))&&!(x1||x2)"
+	g.Expect(selector.String()).To(gomega.Equal(expected))
 	// other
 	selector = RuleSelector{}
 	selector.Included = []string{
@@ -67,6 +84,21 @@ func TestRuleSelector(t *testing.T) {
 		"konveyor.io/target=t2",
 	}
 	expected = "(p1||p2)||(konveyor.io/target=t1||konveyor.io/target=t2)"
+	g.Expect(selector.String()).To(gomega.Equal(expected))
+	// excluded (one)
+	selector = RuleSelector{}
+	selector.Excluded = []string{
+		"x1",
+	}
+	expected = "!x1"
+	g.Expect(selector.String()).To(gomega.Equal(expected))
+	// excluded (many)
+	selector = RuleSelector{}
+	selector.Excluded = []string{
+		"x1",
+		"x2",
+	}
+	expected = "!(x1||x2)"
 	g.Expect(selector.String()).To(gomega.Equal(expected))
 }
 

--- a/cmd/cmd_test.go
+++ b/cmd/cmd_test.go
@@ -21,7 +21,7 @@ func TestRuleSelector(t *testing.T) {
 		"konveyor.io/target=t2",
 	}
 	expected :=
-		"(p1||p2)||((konveyor.io/source=s1||konveyor.io/source=s2)&&(konveyor.io/target=t1||konveyor.io/target=t2))"
+		"((p1||p2)||((konveyor.io/source=s1||konveyor.io/source=s2)&&(konveyor.io/target=t1||konveyor.io/target=t2)))"
 	g.Expect(selector.String()).To(gomega.Equal(expected))
 	// all clauses
 	selector = RuleSelector{}
@@ -38,7 +38,7 @@ func TestRuleSelector(t *testing.T) {
 		"x2",
 	}
 	expected =
-		"((p1||p2)||((konveyor.io/source=s1||konveyor.io/source=s2)&&(konveyor.io/target=t1||konveyor.io/target=t2)))&&!(x1||x2)"
+		"(((p1||p2)||((konveyor.io/source=s1||konveyor.io/source=s2)&&(konveyor.io/target=t1||konveyor.io/target=t2)))&&!(x1||x2))"
 	g.Expect(selector.String()).To(gomega.Equal(expected))
 	// other
 	selector = RuleSelector{}
@@ -57,7 +57,7 @@ func TestRuleSelector(t *testing.T) {
 		"konveyor.io/target=t2",
 	}
 	expected =
-		"(konveyor.io/source=s1||konveyor.io/source=s2)&&(konveyor.io/target=t1||konveyor.io/target=t2)"
+		"((konveyor.io/source=s1||konveyor.io/source=s2)&&(konveyor.io/target=t1||konveyor.io/target=t2))"
 	g.Expect(selector.String()).To(gomega.Equal(expected))
 	// sources
 	selector = RuleSelector{}
@@ -83,7 +83,7 @@ func TestRuleSelector(t *testing.T) {
 		"konveyor.io/target=t1",
 		"konveyor.io/target=t2",
 	}
-	expected = "(p1||p2)||(konveyor.io/target=t1||konveyor.io/target=t2)"
+	expected = "((p1||p2)||(konveyor.io/target=t1||konveyor.io/target=t2))"
 	g.Expect(selector.String()).To(gomega.Equal(expected))
 	// excluded (one)
 	selector = RuleSelector{}

--- a/cmd/rules.go
+++ b/cmd/rules.go
@@ -439,7 +439,10 @@ func (r *Labels) injectAlways(paths []string) (err error) {
 		}
 		return
 	}
-	ruleSelector := RuleSelector{Included: r.Included}
+	ruleSelector := RuleSelector{
+		Included: r.Included,
+		Excluded: r.Excluded,
+	}
 	selector := ruleSelector.String()
 	if selector == "" {
 		return
@@ -563,20 +566,6 @@ func (r *RuleSelector) String() (selector string) {
 	selector = r.join("||", other...)
 	selector = r.join("||", selector, r.join("&&", ands...))
 	selector = r.join("&&", selector, r.notjoin("||", r.Excluded...))
-	selector = r.trim(selector)
-	return
-}
-
-// trim unnecessary outer () created by joins.
-// Example:
-//  ((a||b)&&(c||d))
-// trimmed:
-//  (a||b)&&(c||d)
-func (r *RuleSelector) trim(in string) (out string) {
-	out = in
-	if strings.HasPrefix(out, "((") && strings.HasSuffix(out, ")") {
-		out = out[1 : len(out)-1]
-	}
 	return
 }
 

--- a/cmd/rules.go
+++ b/cmd/rules.go
@@ -598,11 +598,9 @@ func (r *RuleSelector) notjoin(operator string, operands ...string) (joined stri
 	switch len(packed) {
 	case 0:
 	case 1:
-		joined = "!"
-		joined += strings.Join(packed, operator)
+		joined = "!" + strings.Join(packed, operator)
 	default:
-		joined = "!"
-		joined += "(" + strings.Join(packed, operator) + ")"
+		joined = "!(" + strings.Join(packed, operator) + ")"
 	}
 	return
 }

--- a/cmd/rules.go
+++ b/cmd/rules.go
@@ -587,7 +587,7 @@ func (r *RuleSelector) join(operator string, operands ...string) (joined string)
 	return
 }
 
-// notjoin joins clauses and injects ! prefix.
+// notjoin joins clauses and injects `!` prefix.
 func (r *RuleSelector) notjoin(operator string, operands ...string) (joined string) {
 	var packed []string
 	for _, s := range operands {


### PR DESCRIPTION
Support excluded labels in the rule selector.
```
rules:
  labels:
    excluded:
       - noincludejsp
    included:
      - konveyor.io/target=containerization
      - konveyor.io/target=linux
```
produces selector:
```
(konveyor.io/target=containerization||konveyor.io/target=linux)&&!noincludejsp
```
---

```
rules:
  labels:
    excluded:
       - noincludejsp
       - noincludelx
    included:
      - konveyor.io/target=containerization
      - konveyor.io/target=linux
```
produces selector:
```
(konveyor.io/target=containerization||konveyor.io/target=linux)&&!(noincludejsp||noincludelx)
```

Related to: https://issues.redhat.com/browse/MTA-4973

--- 

No longer trimming the outside (). This was being done in an effort to reduce _noise_ in the selector in some cases. Not worth the even minor complexity and had a non-zero chance of causing a problem.