### PR TITLE
:sparkles: use default creds.

### DIFF
--- a/cmd/mode.go
+++ b/cmd/mode.go
@@ -68,6 +68,15 @@ func (r *Mode) fetchRepository(application *api.Application) (err error) {
 		err = errors.New("Application repository not defined.")
 		return
 	}
+	var options []any
+	idapi := addon.Application.Identity(application.ID)
+	identity, found, err := idapi.Find("source")
+	if err != nil {
+		return
+	}
+	if found {
+		options = append(options, identity)
+	}
 	SourceDir = path.Join(
 		SourceDir,
 		strings.Split(
@@ -78,7 +87,7 @@ func (r *Mode) fetchRepository(application *api.Application) (err error) {
 	r.Repository, err = repository.New(
 		SourceDir,
 		application.Repository,
-		application.Identities)
+		options...)
 	if err != nil {
 		return
 	}

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ toolchain go1.22.0
 require (
 	github.com/gin-gonic/gin v1.9.1
 	github.com/konveyor/analyzer-lsp v0.7.0-alpha.2.0.20250528164516-ec5a199590bf
-	github.com/konveyor/tackle2-addon v0.7.0-rc.1.0.20250604115244-17140aad3dd4
+	github.com/konveyor/tackle2-addon v0.7.2-0.20250710151242-382302a6e48d
 	github.com/konveyor/tackle2-hub v0.7.0-alpha.2.0.20250708195852-4e3f74795b04
 	github.com/onsi/gomega v1.31.1
 	github.com/rogpeppe/go-internal v1.10.0

--- a/go.sum
+++ b/go.sum
@@ -151,8 +151,8 @@ github.com/klauspost/cpuid/v2 v2.2.4 h1:acbojRNwl3o09bUq+yDCtZFc1aiwaAAxtcn8YkZX
 github.com/klauspost/cpuid/v2 v2.2.4/go.mod h1:RVVoqg1df56z8g3pUjL/3lE5UfnlrJX8tyFgg4nqhuY=
 github.com/konveyor/analyzer-lsp v0.7.0-alpha.2.0.20250528164516-ec5a199590bf h1:zzDuUJmF2wGW1ra+upIMHHEKC9MUfjvD5Ehm4jaX188=
 github.com/konveyor/analyzer-lsp v0.7.0-alpha.2.0.20250528164516-ec5a199590bf/go.mod h1:/7nwwqN27iODJy/PBai9W16KH91LrPGx1nwu21+rCOg=
-github.com/konveyor/tackle2-addon v0.7.0-rc.1.0.20250604115244-17140aad3dd4 h1:cXh9HGpCMFnmUMdO6/5rbC28pFrhMps5fVyqBqYQk9Y=
-github.com/konveyor/tackle2-addon v0.7.0-rc.1.0.20250604115244-17140aad3dd4/go.mod h1:mITXAU1o/8ZdBoGacaTZxXORfFe1q2S74W9RfTHHm7A=
+github.com/konveyor/tackle2-addon v0.7.2-0.20250710151242-382302a6e48d h1:+ui8IV7S5g4Rhbr8Kt7O3su64CsNnNeEexgYgTofHq8=
+github.com/konveyor/tackle2-addon v0.7.2-0.20250710151242-382302a6e48d/go.mod h1:mITXAU1o/8ZdBoGacaTZxXORfFe1q2S74W9RfTHHm7A=
 github.com/konveyor/tackle2-hub v0.7.0-alpha.2.0.20250708195852-4e3f74795b04 h1:XwNHikN+DB1xpSOYfbHgmwXdtFzKPLZJgYMWLQUIw7s=
 github.com/konveyor/tackle2-hub v0.7.0-alpha.2.0.20250708195852-4e3f74795b04/go.mod h1:RdQChIneyr3sRRg9X9r2f+EYGLVKXVPiFApOSy3Nq0U=
 github.com/kr/pretty v0.2.0/go.mod h1:ipq/a2n7PKx3OHsz4KJII5eveXtPO4qwEXGdVfWzfnI=


### PR DESCRIPTION
use default creds.

Note: The repository.Repository no longer finds the appropriate identity.  The addon needs to find the appropriate identity and pass it as an option.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated a core dependency to a newer version for improved stability and compatibility.

* **Bug Fixes**
  * Improved handling of repository initialization options, enhancing reliability when working with application identities.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->