### PR TITLE
:bug: Fix target repository creds.

### DIFF
--- a/cmd/rules.go
+++ b/cmd/rules.go
@@ -222,7 +222,8 @@ func (r *Rules) addRuleSetRepository(ruleset *api.RuleSet) (err error) {
 	}
 	var options []any
 	if ruleset.Identity != nil {
-		identity, err := addon.Identity.Get(ruleset.Identity.ID)
+		var identity *api.Identity
+		identity, err = addon.Identity.Get(ruleset.Identity.ID)
 		if err == nil {
 			options = append(options, identity)
 		} else {

--- a/cmd/rules.go
+++ b/cmd/rules.go
@@ -220,14 +220,19 @@ func (r *Rules) addRuleSetRepository(ruleset *api.RuleSet) (err error) {
 	if err != nil {
 		return
 	}
-	var ids []api.Ref
+	var options []any
 	if ruleset.Identity != nil {
-		ids = []api.Ref{*ruleset.Identity}
+		identity, err := addon.Identity.Get(ruleset.Identity.ID)
+		if err == nil {
+			options = append(options, identity)
+		} else {
+			return
+		}
 	}
 	rp, err := repository.New(
 		rootDir,
 		ruleset.Repository,
-		ids)
+		options...)
 	if err != nil {
 		return
 	}


### PR DESCRIPTION
This spot missed.  
Related to: https://github.com/konveyor/tackle2-addon/pull/75 - handle working with multiple repositories concurrently in 0.8.

```
    - '[RULESET] fetching: id=30 (__Target(Test)-ac32d015-93df-11f0-8d81-4661cd220ef3)'
    - '[GIT] Home (directory): /addon/.git/8c35e7c2'
    - '[GIT] Cloning: https://github.com/abrugaro/book-server'
    - '[CMD] /usr/bin/git succeeded.'
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling when associating identities with ruleset repositories so identity lookup failures are reported early and prevent partial repository setup.

* **Refactor**
  * Repository initialization updated to a more flexible options-based pattern, improving extensibility while preserving existing behavior for users.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->