### PR TITLE
:sparkles: Upload jdtls log to analysis attachments

### DIFF
--- a/cmd/analyzer.go
+++ b/cmd/analyzer.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"io"
 	"os"
 	"path"
 
@@ -58,25 +57,7 @@ func (r *Analyzer) Run() (insights *builder.Insights, deps *builder.Deps, err er
 		}
 		metadataLog := path.Join(Dir, ".metadata", ".log")
 		if _, stErr := os.Stat(metadataLog); stErr == nil {
-			// Copy to provider-jdtls.log before uploading
-			renamedLog := path.Join(Dir, "provider-jdtls.log")
-			var src, dst *os.File
-			src, err = os.Open(metadataLog)
-			if err != nil {
-				return
-			}
-			defer src.Close()
-			dst, err = os.Create(renamedLog)
-			if err != nil {
-				return
-			}
-			defer dst.Close()
-			_, err = io.Copy(dst, src)
-			if err != nil {
-				return
-			}
-			// Upload the renamed file
-			f, pErr = addon.File.Post(renamedLog)
+			f, pErr = addon.File.Post(metadataLog)
 			if pErr != nil {
 				err = pErr
 				return


### PR DESCRIPTION
In java provider, there is a `.metadata/.log` file with full output of jdtls. This might be needed for debugging, adding it to analysis tasks attachments (under more descriptive `provider-jdtls.log` name).

There were konveyor-related entires of this log already part of provider log, but this PR adds ful content of the jdtls log file.

Fixes: https://github.com/konveyor/tackle2-addon-analyzer/issues/177

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Diagnostic upload now automatically includes available metadata logs alongside primary outputs and dependencies.
  * Improves troubleshooting by ensuring richer diagnostic data is submitted when a metadata log exists, with existing error handling preserved.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->