### PR TITLE
:sparkles: Adding label selector use for selecting ruleset's to download

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/konveyor/tackle2-addon-analyzer
 
-go 1.23.0
+go 1.24.0
 
 toolchain go1.24.11
 


### PR DESCRIPTION

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Replaced many inline label-match checks with a centralized, data-driven test validating ruleset filtering across multiple included/excluded label scenarios.

* **Refactor**
  * Reworked ruleset filtering to use a selector-driven approach that collects rule labels and applies selector-based matching for more reliable results.

* **Chores**
  * Bumped Go language requirement to 1.24.0.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

fixes #183 