### PR TITLE
:ghost: Use packages in ubi9.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,11 +5,6 @@ RUN make cmd
 
 FROM quay.io/konveyor/analyzer-lsp:latest
 USER root
-RUN echo -e "[centos9]" \
- "\nname = centos9" \
- "\nbaseurl = http://mirror.stream.centos.org/9-stream/AppStream/\$basearch/os/" \
- "\nenabled = 1" \
- "\ngpgcheck = 0" > /etc/yum.repos.d/centos.repo
 RUN microdnf -y install \
  glibc-langpack-en \
  openssh-clients \


### PR DESCRIPTION
Don't remember why we originally pulled these packages from centos but the same version of git and svn in ubi9.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Simplified Docker container configuration by removing unused repository setup.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->